### PR TITLE
Disable closeOnOverlayClick WorkouteditorModal

### DIFF
--- a/frontend/src/components/Modals/WorkoutEditorModal.tsx
+++ b/frontend/src/components/Modals/WorkoutEditorModal.tsx
@@ -41,7 +41,12 @@ export const WorkoutEditorModal = () => {
         onClick={onOpen}
       />
 
-      <Modal isOpen={isOpen} onClose={onClose} size="4xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        closeOnOverlayClick={false}
+        size="4xl"
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>


### PR DESCRIPTION

https://user-images.githubusercontent.com/21218279/146218877-3012e5b2-2339-413a-9580-4329e72fd2aa.mov

Man kunne vurdert å bare ha det i selve editoren, men føler det er greit å ha på hele