### PR TITLE
Tidy up the bottom bar

### DIFF
--- a/frontend/src/components/BottomBar.tsx
+++ b/frontend/src/components/BottomBar.tsx
@@ -19,7 +19,7 @@ export const BottomBar = () => {
   const bgColor = useColorModeValue('gray.200', 'gray.900');
   return (
     <Center width="100%" position="fixed" bottom="0">
-      <Stack width="100%">
+      <Stack width="100%" spacing="0">
         <Grid
           backgroundColor={bgColor}
           width="100%"
@@ -47,7 +47,7 @@ export const BottomBar = () => {
         </Grid>
         {!bluetoothIsAvailable ? (
           <Center p="2" backgroundColor="red">
-            <Text fontSize="xl">
+            <Text fontSize="l">
               Bluetooth is not available in this browser yet. Check{' '}
               <Link
                 textDecor="underline"


### PR DESCRIPTION
Tidying up the bottom bar by making the potential `!bluetoothIsAvailable` banner use a smaller font and fixing the jittery logo scaling by using a pixel size for the logo.

| Before | After |
| ----------------------- | --------------------|
| ![image](https://user-images.githubusercontent.com/31168035/149846160-90d3a83b-62e4-46eb-ab56-dcdf292f18ff.png) | ![image](https://user-images.githubusercontent.com/31168035/149846102-4aa237bb-dce7-4426-ba75-c23f84ea42e0.png) |