### PR TITLE
Make top and action bar click-through

### DIFF
--- a/frontend/src/components/ActionBar.tsx
+++ b/frontend/src/components/ActionBar.tsx
@@ -39,7 +39,14 @@ export const ActionBar = () => {
 
   const { colorMode, setColorMode } = useColorMode();
   return (
-    <Stack position="fixed" right="5" top="5" alignItems="flex-end" spacing="1">
+    <Stack
+      position="fixed"
+      right="5"
+      top="5"
+      alignItems="flex-end"
+      spacing="1"
+      pointerEvents="none"
+    >
       {user.loggedIn ? <ProfileModal /> : <LoginModal />}
       {activeGroupSession ? (
         <Text fontSize="lg" fontWeight="bold">

--- a/frontend/src/components/ActionBarItem.tsx
+++ b/frontend/src/components/ActionBarItem.tsx
@@ -36,6 +36,7 @@ export const ActionBarItem = ({ text, icon, onClick, iconColor }: Props) => {
         isRound
         size="lg"
         {...color}
+        pointerEvents="auto"
       />
     </HStack>
   );

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -41,6 +41,7 @@ export const TopBar = ({ timeElapsed }: Props) => {
       textShadow={textShadow}
       fontWeight="bold"
       textAlign="center"
+      pointerEvents="none"
     >
       <Stack width={['70%', '80%', '100%']}>
         <Center width="100%">


### PR DESCRIPTION
The top and action bars were blocking every underlying mouse event - i made these click-through by disabling `pointerEvents` at the root of both the components. The child components would then have to explicitly enable pointer events where they are needed, which imo is just fine.

## Before
![2022-01-18 12 34 02](https://user-images.githubusercontent.com/31168035/149930762-b3e5341f-ded1-4519-8615-8cfbf5800522.gif)

![2022-01-18 12 35 59](https://user-images.githubusercontent.com/31168035/149930672-510fdc58-25f6-4740-814a-586079dfe002.gif)

## After
![2022-01-18 12 33 22](https://user-images.githubusercontent.com/31168035/149930709-51e1d993-3619-432f-9ae8-c84bfcda46ff.gif)

Should probably have enabled mouse recording on these.. 🤦 
