### PR TITLE
Reconnecting to websockets when trying to open group session modal

### DIFF
--- a/frontend/src/components/Modals/GroupSessionModal.tsx
+++ b/frontend/src/components/Modals/GroupSessionModal.tsx
@@ -17,13 +17,16 @@ import { CreateOrJoinGroupSession } from '../GroupSession/CreateOrJoinGroupSessi
 export const GroupSessionModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const { activeGroupSession } = useWebsocket();
+  const { activeGroupSession, connect } = useWebsocket();
   return (
     <>
       <ActionBarItem
         text="Open group session overview"
         icon={<Icon as={activeGroupSession ? PeopleFill : People} />}
-        onClick={onOpen}
+        onClick={() => {
+          onOpen();
+          connect();
+        }}
       />
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />


### PR DESCRIPTION
Reconnecting to the WS server when trying to access the group session view. Since all the WS activity is only accessible behind the group session view, I think this should be a simple solution on dealing with reconnects without the user noticing. 

We could also explicitly do the connect when the group session view is first opened - but as long as we don't have too much traffic, this should be fine. The only difference you would have to do is to change the default value of the `socket` to `React.useState(null)`. 

I've also extended the disconnect time of the server from 1 minute (default) to 10 minutes - so the "Nothing happens when I press the join button"-days are hopefully over 🐸 

Solving #73 