### PR TITLE
Fix useEffect deps triggering loads of updates

### DIFF
--- a/frontend/src/context/WorkoutContext.tsx
+++ b/frontend/src/context/WorkoutContext.tsx
@@ -169,6 +169,10 @@ export const ActiveWorkoutContextProvider = ({
       setResistance(targetPowerAsWatt);
     }
   }, [
+    /* NB: Only include the necessary attributes, since including the
+     *     whole activeWorkout object would lead to a re-render every
+     *     time activeWorkout.partElapsedTime is updated.
+     * */
     activeWorkout.isDone,
     activeWorkout.isActive,
     activeWorkout.activePart,


### PR DESCRIPTION
Changed this in a recent PR - When testing it I got reminded why I didn't use deconstruction. Since the `activeWorkout` object contains `partElapsedTime`, we don't want it to be in the dependancy array triggering an update every time `partElapsedTime` is changed.