### PR TITLE
Fixes to make Safari able to handle the MainActionBar

### DIFF
--- a/frontend/src/components/MainActionBar.tsx
+++ b/frontend/src/components/MainActionBar.tsx
@@ -27,7 +27,7 @@ export const MainActionBar = () => {
 
   const bgColor = useColorModeValue('gray.200', 'gray.900');
   return (
-    <Center mb="5">
+    <Center mb="5" mx="2">
       <Stack p="5" borderRadius="1em" bgColor={bgColor} pointerEvents="auto">
         {showWorkoutControls ? <WorkoutControls /> : null}
         {showPowerControls ? <PowerControls /> : null}
@@ -45,7 +45,7 @@ export const MainActionBar = () => {
             </HStack>
           </Center>
         ) : null}
-        <Grid templateColumns="1fr 1fr 1fr" gap="1" alignItems="end">
+        <Grid templateColumns="1fr 1fr 1fr" gap="1" height="3em">
           <Center height="100%">
             <HStack>
               <SelectWorkoutButton />

--- a/frontend/src/components/MainActionBar/PausedWorkoutButtons.tsx
+++ b/frontend/src/components/MainActionBar/PausedWorkoutButtons.tsx
@@ -7,7 +7,7 @@ export const PausedWorkoutButtons = () => {
   if (isRunning || !hasValidData) return null;
 
   return (
-    <Grid templateColumns="1fr 1fr 1fr" gap="1">
+    <Grid templateColumns="1fr 1fr 1fr" gap="1" height="2.5em">
       <Text />
       <Center width="8em">
         <DownloadTCXButton />


### PR DESCRIPTION
Safari (and mobile browsers) apparently struggled to place the buttons on the `MainActionBar` correctly. They managed to render it by providing some non-relative height - hopefully there's a better way of fixing it, but this will do for now.

| Before | After |
| ------ | ------| 
| ![image](https://user-images.githubusercontent.com/31168035/151202033-cfa1d146-bf21-4c51-aaf8-b97f5dd95fdf.png) | ![image](https://user-images.githubusercontent.com/31168035/151201970-37f43734-a5ec-4bd1-a6ca-694c699f2379.png) |

Solving #133 