### PR TITLE
Use workout without saving + Discard workout changes dialog

### DIFF
--- a/frontend/src/components/Modals/WorkoutEditorModal.tsx
+++ b/frontend/src/components/Modals/WorkoutEditorModal.tsx
@@ -15,6 +15,16 @@ import { WorkoutEditor } from '../WorkoutMenu/WorkoutEditor';
 import { useUser } from '../../context/UserContext';
 import { useWorkoutEditorModal } from '../../context/ModalContext';
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+  HStack,
+} from '@chakra-ui/react';
 
 export interface WorkoutToEdit extends Workout {
   type: 'local' | 'remote' | 'new';
@@ -27,8 +37,18 @@ export const WorkoutEditorModal = () => {
     React.useState<WorkoutToEdit | null>(null);
 
   const { setActiveWorkout } = useActiveWorkout();
+  const [isWorkoutUnsaved, setIsWorkoutUnsaved] = React.useState(false);
+  const [showDiscardDialog, setShowDiscardDialog] = React.useState(false);
+  const cancelRef = React.useRef<HTMLButtonElement>(null);
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="4xl">
+    <Modal
+      isOpen={isOpen}
+      onClose={() =>
+        isWorkoutUnsaved ? setShowDiscardDialog(true) : onClose()
+      }
+      size="4xl"
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
@@ -55,6 +75,7 @@ export const WorkoutEditorModal = () => {
               refetchUserData();
               setWorkoutToEdit(null);
             }}
+            setIsWorkoutUnsaved={setIsWorkoutUnsaved}
           />
         ) : (
           <WorkoutOverview
@@ -66,6 +87,45 @@ export const WorkoutEditorModal = () => {
           />
         )}
       </ModalContent>
+      <AlertDialog
+        isOpen={showDiscardDialog}
+        leastDestructiveRef={cancelRef}
+        onClose={() => setShowDiscardDialog(false)}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Discard workout changes
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              You have unsaved changes in this workout. Closing this would
+              discard the changes.
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <HStack>
+                <Button
+                  colorScheme="red"
+                  onClick={() => {
+                    setShowDiscardDialog(false);
+                    onClose();
+                  }}
+                  ml={3}
+                >
+                  Yes, discard the changes
+                </Button>
+                <Button
+                  ref={cancelRef}
+                  onClick={() => setShowDiscardDialog(false)}
+                >
+                  Cancel
+                </Button>
+              </HStack>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </Modal>
   );
 };

--- a/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -30,9 +30,29 @@ import {
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
 import { createZoneTableInfo } from '../../utils/zones';
 import { secondsToHoursMinutesAndSecondsString } from '../../utils/time';
+
+const editableWorkoutIsEqualToLoaded = (
+  editable: EditableWorkout,
+  loaded: WorkoutToEdit
+) => {
+  if (editable.name !== loaded.name) return false;
+  if (editable.parts.length !== loaded.parts.length) return false;
+
+  for (let i = 0; i < editable.parts.length; i++) {
+    const editablePart = editable.parts[i];
+    const loadedPart = loaded.parts[i];
+
+    if (editablePart.duration !== loadedPart.duration) return false;
+    if (editablePart.targetPower !== loadedPart.targetPower) return false;
+  }
+
+  return true;
+};
+
 interface Props {
   workout: WorkoutToEdit;
   closeEditor: () => void;
+  setIsWorkoutUnsaved: (isUnsaved: boolean) => void;
 }
 
 interface EditableWorkoutPart extends WorkoutPart {
@@ -45,6 +65,7 @@ interface EditableWorkout extends Workout {
 export const WorkoutEditor = ({
   workout: loadedWorkout,
   closeEditor,
+  setIsWorkoutUnsaved,
 }: Props) => {
   const { activeFtp, setActiveFtp, setActiveWorkout } = useActiveWorkout();
   const { user, saveLocalWorkout } = useUser();
@@ -72,6 +93,14 @@ export const WorkoutEditor = ({
     ...loadedWorkout,
     parts: loadedWorkout.parts.map((part, i) => ({ ...part, id: i })),
   });
+
+  const workoutIsUnsaved =
+    loadedWorkout.type === 'new' ||
+    !editableWorkoutIsEqualToLoaded(workout, loadedWorkout);
+
+  React.useEffect(() => {
+    setIsWorkoutUnsaved(workoutIsUnsaved);
+  }, [workoutIsUnsaved, setIsWorkoutUnsaved]);
   const totalDuration = workout.parts.reduce(
     (sum, part) => sum + part.duration,
     0

--- a/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -46,7 +46,7 @@ export const WorkoutEditor = ({
   workout: loadedWorkout,
   closeEditor,
 }: Props) => {
-  const { activeFtp, setActiveFtp } = useActiveWorkout();
+  const { activeFtp, setActiveFtp, setActiveWorkout } = useActiveWorkout();
   const { user, saveLocalWorkout } = useUser();
   const token = user.loggedIn && user.token;
 
@@ -228,6 +228,10 @@ export const WorkoutEditor = ({
               Save locally
             </Button>
           ) : null}
+          <Button onClick={() => setActiveWorkout(workout)}>
+            Use without saving
+          </Button>
+
           <Button onClick={closeEditor}>Cancel</Button>
         </HStack>
         {!user.loggedIn ? (

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -3,4 +3,6 @@ import * as gps from './gps';
 import * as time from './time';
 import * as zones from './zones';
 
-export default { general, gps, time, zones };
+const utils = { general, gps, time, zones };
+
+export default utils;


### PR DESCRIPTION
Make it possible to use a workout without saving it. This may come in handy when you want to try one of your friends workouts, but don't want to save it for some reason - or when you want to do some changes for todays workout, but you probably want to change it back later.

Also adding a dialog when attempting to exit the workout editor when there are unsaved changes.
![2022-01-30 22 28 37](https://user-images.githubusercontent.com/31168035/151718649-ce461795-1098-4382-8994-1732aee86fc5.gif)

