### PR TITLE
Display untracked data

### DIFF
--- a/frontend/src/colors.ts
+++ b/frontend/src/colors.ts
@@ -2,6 +2,7 @@ import theme from './theme';
 
 export const powerColor = theme.colors.purple[500];
 export const hrColor = theme.colors.red[500];
+export const untrackedColor = theme.colors.gray[500];
 
 export const hrColors = [
   theme.colors.red[500],

--- a/frontend/src/components/Graph/CustomGraphTooltip.tsx
+++ b/frontend/src/components/Graph/CustomGraphTooltip.tsx
@@ -11,15 +11,15 @@ interface Payload {
 
 interface Props {
   active?: boolean;
-  label?: string;
   payload?: Payload[];
 }
 
-const formatLine = (name: string, value: number) => {
-  const unit = name.split(' ')[1] === 'HR' ? ' bpm' : ' W';
-  return [`${name.split(' ')[0]}`, value, unit];
+const formatLine = (label: string, value: number) => {
+  const unit = label.split(' ')[1] === 'HR' ? ' bpm' : ' W';
+  const name = label.split(' ')[0];
+  return [`${name === 'You-Untracked' ? 'You' : name}`, value, unit];
 };
-export const CustomGraphTooltip = ({ active, payload, label }: Props) => {
+export const CustomGraphTooltip = ({ active, payload }: Props) => {
   const bgColor = useColorModeValue('white', 'gray.800');
   if (active && payload && payload.length) {
     return (

--- a/frontend/src/components/Graph/GraphContainer.tsx
+++ b/frontend/src/components/Graph/GraphContainer.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-bootstrap-icons';
 import { GraphCheckboxes } from './GraphCheckboxes';
 import { useWebsocket } from '../../context/WebsocketContext';
-import { useData } from '../../context/DataContext';
 
 export interface ShowData {
   hr: boolean;
@@ -20,9 +19,6 @@ export interface ShowData {
 }
 
 export const GraphContainer = () => {
-  const { data: rawData } = useData();
-  const data = rawData.flatMap((x) => x.dataPoints);
-
   const [showFill, setShowFill] = React.useState(true);
   const toggleGraphFillButtonText = showFill
     ? 'Hide graph fill'
@@ -54,7 +50,6 @@ export const GraphContainer = () => {
   const graphs = React.useMemo(
     () => (
       <Graphs
-        data={data}
         showFill={showFill}
         showUserData={showUserData}
         showOtherUsersData={showOtherUsersData}
@@ -62,14 +57,7 @@ export const GraphContainer = () => {
         otherUsers={otherUsers}
       />
     ),
-    [
-      data,
-      showFill,
-      showUserData,
-      showOtherUsersData,
-      activeGroupSession,
-      otherUsers,
-    ]
+    [showFill, showUserData, showOtherUsersData, activeGroupSession, otherUsers]
   );
   return (
     <Stack width="100%" mb={showOptions ? '20em' : '0'}>


### PR DESCRIPTION
Display untracked data when HR or Power is available, but the user isn't recording the data. 

I played around with the stroke and so on, but I think it looked nicest as pure gray when untracked.
![2022-01-31 20 38 48](https://user-images.githubusercontent.com/31168035/151861292-3684ce85-bf70-40e1-b1ec-1c67530771ed.gif)

The power bar is not being calculated when the data is untracked - could/should probably be fixed :^)