### PR TITLE
Remove total duration in table

### DIFF
--- a/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -310,16 +310,6 @@ export const WorkoutEditor = ({
             )
           )}
         </Tbody>
-        <Tfoot>
-          <Tr>
-            <Td fontWeight="bold">Total</Td>
-            <Td></Td>
-            <Td></Td>
-            <Td fontWeight="bold" textAlign="right">
-              {secondsToHoursMinutesAndSecondsString(totalDuration)}
-            </Td>
-          </Tr>
-        </Tfoot>
       </Table>
     </Stack>
   );


### PR DESCRIPTION
I think this I redundant because of the "total duration" .

It is of course possible to keep this and delete the other.

Before : 
<img width="951" alt="image" src="https://user-images.githubusercontent.com/21218279/184989834-5aaa8ded-b615-4b3d-a058-999e4311f9e7.png">


After : <img width="1017" alt="image" src="https://user-images.githubusercontent.com/21218279/184989784-6d53da5e-7ebd-49ce-aae1-0bc119ac13e2.png">
