### PR TITLE
Navigate to workout route after importing workout data

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
@@ -13,6 +13,7 @@ import { importWorkout } from '../../api';
 import { Text } from '@chakra-ui/layout';
 import { WorkoutToEdit } from '../Modals/WorkoutEditorModal';
 import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export enum ApiStatus {
   SUCCESS = 'SUCCESS',
@@ -31,6 +32,8 @@ export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
   const [workoutIdInput, setWorkoutIdInput] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
 
+  const navigate = useNavigate();
+
   const workoutIdInputIsValidFormat =
     workoutIdInput.match('([a-zA-Z0-9]+-[0-9]+)') !== null;
 
@@ -47,6 +50,7 @@ export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
             type: 'new',
             previewFtp,
           });
+          navigate('workout');
           return;
         }
         case ApiStatus.FAILURE: {
@@ -58,7 +62,7 @@ export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
         }
       }
     },
-    [setIsLoading, previewFtp, setWorkoutToEdit]
+    [setIsLoading, previewFtp, setWorkoutToEdit, navigate]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
This fixes a bug that takes you back into editor after you saved
Fixes #201

Before 🥷 : 
![image](https://user-images.githubusercontent.com/21218279/200116504-97b4e1dc-05d1-44ca-b789-1225f8c8fac9.png)

now :
![2022-11-05 11 54 11](https://user-images.githubusercontent.com/21218279/200116469-97486c1e-89f8-4df1-8752-6a0fd0b66e37.gif)
