### PR TITLE
Fixes wattFromFtpPercent rounding error

### DIFF
--- a/apps/frontend/src/utils/general.ts
+++ b/apps/frontend/src/utils/general.ts
@@ -65,4 +65,4 @@ export const ftpPercentFromWatt = (watt: number, ftp: number) =>
   Math.floor(1000 * (watt / ftp)) / 10;
 
 export const wattFromFtpPercent = (ftpPercent: number, ftp: number) =>
-  Math.floor((ftpPercent / 100) * ftp);
+  Math.floor((ftpPercent * ftp) / 100);


### PR DESCRIPTION
Before it lost precision by dividing before multiplying.
Fixes #200 

Example : 
<img width="232" alt="image" src="https://user-images.githubusercontent.com/21218279/200118796-6bbc6ba4-5c3d-45d2-adcf-2836ddfeb9d8.png">
<img width="859" alt="image" src="https://user-images.githubusercontent.com/21218279/200118977-ef187194-91f6-4670-8fd0-872598fe50fd.png">
