### PR TITLE
Quickfix: Update FTP input if user data is updated

### DIFF
--- a/apps/frontend/src/components/Modals/ProfileModal.tsx
+++ b/apps/frontend/src/components/Modals/ProfileModal.tsx
@@ -35,6 +35,12 @@ export const ProfileModal = () => {
     navigate('/');
   };
 
+  React.useEffect(() => {
+    if (user.loggedIn) {
+      setFtpInput('' + user.ftp);
+    }
+  }, [user]);
+
   if (!user.loggedIn) return null;
 
   const updateFtp = async (input: string) => {


### PR DESCRIPTION
As per now the input is set to 250 since the user object isn't filled with the validated data on the first modal render. Add a hacky `React.useEffect` to temporarily solve this 🤠 