### PR TITLE
Fix generateRandomString

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
-    branches: [ "master" ]
+    branches: ['master']
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -20,25 +19,23 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
-    - run: yarn
-    - run: yarn run build
-
-
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn run build
 
   prettier:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Prettify code
-      uses: creyD/prettier_action@v4.2
-      with:
-        dry: True
-        prettier_options: --check **/*.{ts,tsx,js,md,html,json} #todo add svg
+      - uses: actions/checkout@v3
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          dry: True
+          prettier_options: --check **/*.{ts,tsx,js,md,html,json} #todo add svg

--- a/libs/utils/src/string.ts
+++ b/libs/utils/src/string.ts
@@ -3,7 +3,8 @@ export const padLeadingZero = (nr: number) => (nr < 10 ? '0' + nr : nr);
 export const generateRandomString = (length: number) => {
   const alphabet = '0123456789';
   const generatedString = new Array(length).fill(0).reduce((result) => {
-    return result + alphabet.substring(Math.random() * alphabet.length, 1);
+    const index = Math.random() * alphabet.length;
+    return result + alphabet.substring(index, index + 1);
   }, '') as string;
 
   return generatedString;


### PR DESCRIPTION
`.substr` got replaced by `.substring` during the Granka-scrappening in November (#193), due to `.substr` being officially deprecated. This was obviously not tested thoroughly enough, and lead to weird room ids 🫣

Also; bumped `creyD/prettier_action` to `v4.3` to avoid a [bug](https://github.com/creyD/prettier_action/issues/113). (and formatted the action file :^)))

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/31168035/221298299-94c4a44a-6f02-4842-9620-3b301406ae95.png) | ![image](https://user-images.githubusercontent.com/31168035/221298216-8c86b2bf-6c61-46b9-96ac-d5311c4aa9a8.png) |
