### PR TITLE
Fix HR disconnect bug

### DIFF
--- a/apps/frontend/src/hooks/useHeartRateMonitorInterface.ts
+++ b/apps/frontend/src/hooks/useHeartRateMonitorInterface.ts
@@ -142,7 +142,15 @@ export const useHeartRateMonitorInterface = (): HeartRateMonitorInterface => {
   };
   const disconnect = async () => {
     if (heartRateMonitor.status === 'connected') {
-      await heartRateMonitor.heartRateMeasurementCharacteristic.stopNotifications();
+      try {
+        await heartRateMonitor.heartRateMeasurementCharacteristic.stopNotifications();
+      } catch (e: any) {
+        if (e instanceof DOMException) {
+          console.log('HR already disconnected');
+        } else {
+          throw e;
+        }
+      }
 
       console.log('> Notifications stopped');
       heartRateMonitor.heartRateMeasurementCharacteristic.removeEventListener(


### PR DESCRIPTION
Currently you can not disconnect your hr monitor if it gets out of distance or something else.
The workaround is to refresh, but then you have to connect the trainer and set up workout again ++.
The issue is that we `heartRateMonitor.heartRateMeasurementCharacteristic.stopNotifications();`
throws, because 

index.5094a1d9.js:212 Uncaught (in promise) DOMException: Failed to execute 'stopNotifications' on 'BluetoothRemoteGATTCharacteristic': GATT Server is disconnected. Cannot perform GATT operations. (Re)connect first with `device.gatt.connect`.

Currently: 
![2023-06-10 17 07 54](https://github.com/sivertschou/dundring/assets/21218279/325bd069-d200-4cf2-b458-553b4ab909a6)

But it is already disconnected, so we can just ignore that (i think).
So this code just catches the DOMException and ignores it. Seems to work, for this case at least.

With this fix:

![2023-06-10 17 06 58](https://github.com/sivertschou/dundring/assets/21218279/fe1beba7-6f7e-4012-8701-4ba6647e38b5)


## Other stuff

* If you your hr disconnects, we still keep the same bpm as the last bpm recorded. 
Could maybe be possible to track the timing or something, and set it to null/0 if the last bpm is old
* We should try to add some reconnecting. Seems like it should be possible , even automatic : https://googlechrome.github.io/samples/web-bluetooth/automatic-reconnect-async-await.html
* It would be nice to somehow catch that the HR has disconnected (like mentioned above, or in another way) and make and set status for that.





