### PR TITLE
update prettier to latest and specify version in gha

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,5 +37,6 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
+          prettier_version: '3.0.3'
           dry: True
           prettier_options: --check **/*.{ts,tsx,js,md,html,json} #todo add svg

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/frontend/src/hooks/useSmartTrainerInterface.ts
+++ b/apps/frontend/src/hooks/useSmartTrainerInterface.ts
@@ -156,9 +156,8 @@ export const useSmartTrainerInterface = (): SmartTrainerInterface => {
 
     const server = await device.gatt?.connect();
     try {
-      const fitnessMachineService = await server?.getPrimaryService(
-        'fitness_machine'
-      );
+      const fitnessMachineService =
+        await server?.getPrimaryService('fitness_machine');
 
       if (!fitnessMachineService) {
         return dispatch({
@@ -209,9 +208,8 @@ export const useSmartTrainerInterface = (): SmartTrainerInterface => {
       logEvent(
         'Could not connect to device as Fitness Machine. Trying to connect to cycling power.'
       );
-      const cyclingPowerService = await server?.getPrimaryService(
-        'cycling_power'
-      );
+      const cyclingPowerService =
+        await server?.getPrimaryService('cycling_power');
       if (!cyclingPowerService) {
         return dispatch({
           type: 'set_error',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^13.0.3",
     "node-jq": "^2.3.4",
-    "prettier": "2.5.1",
+    "prettier": "3.0.3",
     "turbo": "^1.4.4"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5858,10 +5858,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
-prettier@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 prettier@>=2.4.0:
   version "2.7.1"


### PR DESCRIPTION
Motivated by prettier issues in #226 .
This makes it so that the versions used locally and in github actions are the same.
Also bump from 2.5 to 3.0 and then prettify the files with the new version 