### PR TITLE
add toast when save remote fails - #214 

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -26,12 +26,14 @@ import {
   Thead,
   Tooltip,
   Tr,
+  useToast,
 } from '@chakra-ui/react';
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
 import { createZoneTableInfo } from '../../utils/zones';
 import { secondsToHoursMinutesAndSecondsString } from '@dundring/utils';
 import { getPowerToSpeedMap } from '../../utils/speed';
 import { ApiStatus } from '@dundring/types';
+import { parseInputAsInt } from '../../utils/general';
 
 const editableWorkoutIsEqualToLoaded = (
   editable: EditableWorkout,
@@ -73,6 +75,7 @@ export const WorkoutEditor = ({
 }: Props) => {
   const { activeFtp, setActiveFtp, setActiveWorkout } = useActiveWorkout();
   const { user, saveLocalWorkout } = useUser();
+  const toast = useToast();
   const token = (user.loggedIn && user.token) || null;
 
   const canSaveLocally =
@@ -81,19 +84,16 @@ export const WorkoutEditor = ({
   const canSaveRemotely =
     token && (loadedWorkout.type === 'new' || loadedWorkout.type === 'remote');
 
-  const parseInputAsInt = (input: string) => {
-    const parsed = parseInt(input);
-    if (isNaN(parsed)) {
-      return 0;
-    }
-    return parsed;
-  };
-
   const saveRemotely = async () => {
     if (token) {
       const res = await saveWorkout(token, { workout });
       if (res.status === ApiStatus.FAILURE) {
-        // TODO: Show error message
+        toast({
+          title: `Save workout remotely failed`,
+          isClosable: true,
+          duration: 5000,
+          status: 'error',
+        });
         return;
       }
       closeEditor();


### PR DESCRIPTION
![2023-09-24 23 37 18](https://github.com/sivertschou/dundring/assets/21218279/1a6b6955-d6f3-4bac-887a-506f4021ea2b)

Should this also be done for saving locally?
I guess that is more stable, but the json parsing and stringifying can can, i guess.
If we do it, I think it would be the best to just wrap the saveLocalWorkout in an error handled toast version in this file.
To keep the toast-ing and error handling for the remote and local save in the same file 