### PR TITLE
Add local db instructions to backend readme

### DIFF
--- a/apps/backend/prepare.sh
+++ b/apps/backend/prepare.sh
@@ -11,6 +11,7 @@ MAIL_HOST=
 MAIL_PORT=
 MAIL_USER=
 MAIL_PASSWORD=
+DATABASE_URL=
 "
 
 echo "backend/prepare.sh – Starting ⚡️"

--- a/apps/backend/readme.md
+++ b/apps/backend/readme.md
@@ -15,3 +15,9 @@ Run the app
 ```
 $ npm start
 ```
+
+### Setup and use local database
+
+1. Set `DATABASE_URL=file:./dundring.db
+
+2. Use Prisma to init the db : `npx prisma migrate dev --name init`


### PR DESCRIPTION
I couldn't find anything about local test DB, so i added this.
Could maybe be moved to the the main readme i guess