### PR TITLE
Change power controls to adjust FTP , not only current interval ⚡ 

### DIFF
--- a/apps/frontend/src/components/MainActionBar/PowerControlButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/PowerControlButton.tsx
@@ -6,19 +6,20 @@ import { wattFromFtpPercent } from '../../utils/general';
 interface Props {
   value: number;
   activeFtp: number;
+  setActiveFtp: (newFtp: number) => void;
 }
 
-export const PowerControlButton = ({ value, activeFtp }: Props) => {
-  const {
-    isConnected: smartTrainerIsConnected,
-    setResistance: setSmartTrainerResistance,
-    currentResistance,
-  } = useSmartTrainer();
+export const PowerControlButton = ({
+  value,
+  activeFtp,
+  setActiveFtp,
+}: Props) => {
+  const { isConnected: smartTrainerIsConnected } = useSmartTrainer();
 
   const canAddResistanceValue = (value: number) => {
     const watt = wattFromFtpPercent(value, activeFtp);
 
-    return currentResistance + watt >= 0;
+    return activeFtp + watt >= 0;
   };
 
   const isPositive = value >= 0;
@@ -33,7 +34,7 @@ export const PowerControlButton = ({ value, activeFtp }: Props) => {
         onClick={() => {
           if (!smartTrainerIsConnected) return;
           const addWatt = wattFromFtpPercent(value, activeFtp);
-          setSmartTrainerResistance(currentResistance + addWatt);
+          setActiveFtp(activeFtp + addWatt);
         }}
         isDisabled={!smartTrainerIsConnected || !canAddResistanceValue(value)}
         size="sm"

--- a/apps/frontend/src/components/MainActionBar/PowerControlButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/PowerControlButton.tsx
@@ -27,7 +27,7 @@ export const PowerControlButton = ({
     <Tooltip
       label={`${isPositive ? '+' : '-'}${Math.abs(
         wattFromFtpPercent(value, activeFtp)
-      )}W (${value}%)`}
+      )}W`}
       placement="top"
     >
       <Button

--- a/apps/frontend/src/components/MainActionBar/PowerControlInput.tsx
+++ b/apps/frontend/src/components/MainActionBar/PowerControlInput.tsx
@@ -25,11 +25,8 @@ interface PowerInputData {
 }
 
 export const PowerControlInput = () => {
-  const { activeFtp } = useActiveWorkout();
-  const {
-    isConnected: smartTrainerIsConnected,
-    setResistance: setSmartTrainerResistance,
-  } = useSmartTrainer();
+  const { setActiveFtp, activeFtp } = useActiveWorkout();
+  const { isConnected: smartTrainerIsConnected } = useSmartTrainer();
 
   const [powerInputData, dispatchPowerInputAction] = React.useReducer(
     (
@@ -145,9 +142,7 @@ export const PowerControlInput = () => {
               if (!smartTrainerIsConnected || powerInputData.power === null)
                 return;
 
-              setSmartTrainerResistance(
-                wattFromFtpPercent(powerInputData.power, activeFtp)
-              );
+              setActiveFtp(wattFromFtpPercent(powerInputData.power, activeFtp));
             }}
           >
             Set

--- a/apps/frontend/src/components/MainActionBar/PowerControls.tsx
+++ b/apps/frontend/src/components/MainActionBar/PowerControls.tsx
@@ -7,13 +7,13 @@ import { PowerControlInput } from './PowerControlInput';
 export const PowerControls = () => {
   const { isConnected: smartTrainerIsConnected } = useSmartTrainer();
 
-  const { activeFtp } = useActiveWorkout();
+  const { activeFtp, setActiveFtp } = useActiveWorkout();
 
   const controlValues = [1, 5, 10, -1, -5, -10];
   return (
     <Stack>
       <Text fontSize="xs" fontWeight="bold" opacity="0.5">
-        Power controls
+        Power controls - adjust current FTP
       </Text>
       <Tooltip
         label="You need to connect a smart trainer to use this functionality."
@@ -23,7 +23,12 @@ export const PowerControls = () => {
         <Center justifyContent="space-between">
           <Grid templateColumns="2fr 2fr 2fr" gap="1">
             {controlValues.map((value, i) => (
-              <PowerControlButton key={i} value={value} activeFtp={activeFtp} />
+              <PowerControlButton
+                key={i}
+                value={value}
+                activeFtp={activeFtp}
+                setActiveFtp={setActiveFtp}
+              />
             ))}
           </Grid>
           <PowerControlInput />


### PR DESCRIPTION
# Change power controls to adjust FTP

This fixes #239 
Also fixes/adds the feature in #240 

## Why
Personally, most of the time i want my adjustments to affect the whole workout,
and not having to change every single interval (and then having to wait for the start of the intervals).
When changing the whole workout, i think the easiest, both coding and conceptually for the users, is to change the workout ftp.

## How it works currently
In a workout with 
```
ftp=200W
int1 : 70% - 140W
int2 : 80% - 160W
```
During int1, changing +10% (20W), will result int

```dundring
ftp=200W
int1 : 70% - 160W
int2 : 80% - 160W
```

## How it works after this PR
In a workout with ftp=200, changing +10% during any interval, means ftp=220, and all intervals will be adjusted.
As can be seen in the gifs


In a workout with 
```dundring
ftp=200W
int1 : 70% - 140W
int2 : 80% - 160W
```
During int1, changing +10% (20W), will result int

```dundring
ftp=220W
int1 : 70% - 154W
int2 : 80% - 176W
```


Set from buttons:
![2023-10-14 12 28 42](https://github.com/sivertschou/dundring/assets/21218279/adcff31c-9577-4d90-8a12-e1e67e1e90e6)

Set from input:
![2023-10-14 12 33 07](https://github.com/sivertschou/dundring/assets/21218279/885451a5-1194-437c-ae1c-fc656ead44e7)




## Considerations
* Depends on how you look at your workout, this may be a bit more confusing.
At least, if your main point is just to increase the interval at 70% from 200 -> 220W,  that means you have to either calculate the FTP where FTP*70%=220 or just click and see.

* Should the power controls be % based at all?
Related to the point above. I think one would probably more often increase by a set number (1,5,10W), instead of %.

* Instead of changing everything to FTP instead of interval, maybe this should be a switch/flip in the power control gui , where you decide what you want. Should be pretty easy

* Maybe these FTP-based power controls should be included in the workout controls?
And the interval-ones, be kept in the power controls? Kinda best of both worlds, functionality wise at least

* Should also add the possibility to actually change a workout during a session. This would maybe get rid of the need of the need of these adjust ftp-buttons, when you can adjust it inside the workout editor. But these buttons are more convenient still



