### PR TITLE
Fix local saving import workout by not copying the id

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
@@ -48,6 +48,7 @@ export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
         case ApiStatus.SUCCESS: {
           setWorkoutToEdit({
             ...workoutResponse.data.workout,
+            id: '',
             type: 'new',
             previewFtp,
           });


### PR DESCRIPTION
_A small change for the dundring codebase, but a big step for the dundring user base._

Currently, you cant save imported workouts locally. This fixes that, ie fixes #242 

Before. it used the imported workout's id, and then the local saving would try to find that id in local storage, and it wouldnt, so it wouldnt do anything

```javascript
 if (workout.id) {
        const updatedWorkouts = [...localWorkouts].map((w) =>
          workout.id === w.id ? workout : w
        );
```

By setting id:"", this won't trigger, and it will save as it should.


A bonus is that now you can import your own workouts to duplicate them 🧠 


![2023-10-14 17 41 54](https://github.com/sivertschou/dundring/assets/21218279/e7e6f5ac-7092-4c2f-9e5a-f016184986c5)
![2023-10-14 17 43 07](https://github.com/sivertschou/dundring/assets/21218279/0f300ec3-28af-4f93-9b1e-ccebb27db110)
