### PR TITLE
Add setIsWorkoutUnsaved(false) to saving and cancel and back buttons

### DIFF
--- a/apps/frontend/src/components/Modals/WorkoutEditorModal.tsx
+++ b/apps/frontend/src/components/Modals/WorkoutEditorModal.tsx
@@ -65,6 +65,7 @@ export const WorkoutEditorModal = () => {
                 mr="1"
                 onClick={() => {
                   navigate('/workout');
+                  setIsWorkoutUnsaved(false);
                   setWorkoutToEdit(null);
                 }}
                 icon={<Icon as={ArrowLeft} />}

--- a/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -96,6 +96,7 @@ export const WorkoutEditor = ({
         });
         return;
       }
+      setIsWorkoutUnsaved(false);
       closeEditor();
     }
   };
@@ -274,6 +275,7 @@ export const WorkoutEditor = ({
             <Button
               onClick={() => {
                 saveLocalWorkout(workout);
+                setIsWorkoutUnsaved(false);
                 closeEditor();
               }}
               leftIcon={<Icon as={Hdd} />}
@@ -291,7 +293,14 @@ export const WorkoutEditor = ({
             Use without saving
           </Button>
 
-          <Button onClick={closeEditor}>Cancel</Button>
+          <Button
+            onClick={() => {
+              setIsWorkoutUnsaved(false);
+              closeEditor();
+            }}
+          >
+            Cancel
+          </Button>
         </HStack>
         {!user.loggedIn ? (
           <FormHelperText>


### PR DESCRIPTION
 Sets setIsWorkoutUnsaved(false) to avoid "discard changes?" popupmenu after:
* saving local - no changes to discard, should not show
* save remote - no changes to discard, should not show
* cancel - when canceling an edit, that should implictely means discard
* back - since there is no "forward" button or easy way to go back to the workout, i would say back is a cancel

I guess cancel and back is debatable, but if it should pop up for them, it should pop up when clicking them, not while exiting the editor after. 
If we want the discard popup for these, I think we should maybe create another/send a popup component to the editor.

But the main reason for this discard popup, was that you lost all of your work when clicking outside the editor, which can happen a lot.
Clicking back and cancel doesnt happen on accident as much, i think.  

The discard still pops up when:
* with changes -> clicking outside the editor to close it
* with changes -> clicking the cross to close

 FIxes #245 

# No popup after saving
![2023-10-14 18 26 06](https://github.com/sivertschou/dundring/assets/21218279/068085a8-5164-497f-aacb-c86f1b77e40f)

# No popup after back and cancel
![2023-10-14 18 26 25](https://github.com/sivertschou/dundring/assets/21218279/a9bad39d-34c8-40b6-9b6d-9520806ab45b)

 ## Pop up when exiting
![2023-10-14 18 26 48](https://github.com/sivertschou/dundring/assets/21218279/6e5ac477-efd2-47a1-92f2-c4b764eac33e)


 
 
 
