### PR TITLE
Fix: Check userId before updating workout

### DIFF
--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -184,6 +184,13 @@ export const upsertWorkout = async (
 > => {
   try {
     /* TODO: Fix this to first upsert the workout and its parts, and then delete the potentially unused workout parts. */
+    const workoutInDB = await prisma.workout.findFirst({
+      where: { id: workoutId },
+    });
+    if (!(workoutInDB?.userId === userId)) {
+      return error('Something went wrong while upserting workout');
+    }
+
     const result = await (workoutId
       ? prisma.workout.update({
           data: { name: workout.name },


### PR DESCRIPTION
Fixes the part of #256 that #244 didn't fix, meaning it
fixes the issue that it was possible to edit someone else's workout through the api.

May be better way to do this, but this seems to work

Tested with curl:

```bash
# without these changes
  curl 'http://localhost:8080/api/me/workout' \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI1NzIzNTRjNS1hMjM2LTRiYmEtODk0OC1kMzMyZDI1OGQ5ZDciLCJ1c2VybmFtZSI6Im1vYmVrayIsImlhdCI6MTY5ODA4NTY3NCwiZXhwIjoxNzA4NDUzNjc0fQ.eICo1Xk_suJTtted6VtlSYaBMpV4C8DiUj5UKg6s-UU' \
  --data-raw '{"workout":{"name":"Test123-rem","id":"f4481478-6499-464d-b25b-a6b286d7b54b","parts":[{"duration":300,"targetPower":70,"type":"steady","id":0},{"duration":300,"targetPower":70,"type":"steady","id":1}
  --compressed
{"status":"FAILURE","message":"Something went wrong while upserting workout"}%

# WITH THESE CHANGES
>
  curl 'http://localhost:8080/api/me/workout' \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI1NzIzNTRjNS1hMjM2LTRiYmEtODk0OC1kMzMyZDI1OGQ5ZDciLCJ1c2VybmFtZSI6Im1vYmVrayIsImlhdCI6MTY5ODA4NTY3NCwiZXhwIjoxNzA4NDUzNjc0fQ.eICo1Xk_suJTtted6VtlSYaBMpV4C8DiUj5UKg6s-UU' \
  --data-raw '{"workout":{"name":"Test123-rem","id":"f4481478-6499-464d-b25b-a6b286d7b54b","parts":
  --compressed
{"status":"SUCCESS","data":{"workout":{"name":"Test123-rem","id":"f4481478-6499-464d-b25b-a6b286d7b54b","parts":
```