### PR TITLE
improve readability and performance of string utils

### DIFF
--- a/libs/utils/src/string.ts
+++ b/libs/utils/src/string.ts
@@ -1,18 +1,17 @@
-export const padLeadingZero = (nr: number) => (nr < 10 ? '0' + nr : nr);
+export const padLeadingZero = (nr: number) => nr.toString().padStart(2, '0');
 
 export const generateRandomString = (length: number) => {
-  const alphabet = '0123456789';
-  const generatedString = new Array(length).fill(0).reduce((result) => {
-    const index = Math.random() * alphabet.length;
-    return result + alphabet.substring(index, index + 1);
-  }, '') as string;
+  const alphabet = '0123456789'.split('');
+  const generatedString = new Array(length)
+    .fill(0)
+    .map(() => {
+      const index = Math.random() * alphabet.length;
+      return alphabet[Math.floor(index)];
+    })
+    .join('');
 
   return generatedString;
 };
 
-export const removeDuplicateWords = (words: string[]) =>
-  words.reduce(
-    (entries, curr) =>
-      entries.every((entry) => entry !== curr) ? [...entries, curr] : entries,
-    [] as string[]
-  );
+export const removeDuplicateWords = (words: string[]): string[] =>
+  Array.from(new Set(words));


### PR DESCRIPTION
I was reading through some of the code and saw potential improvements for the string utilities. Mostly these are just removing `reduce`s, however, for the case of `removeDuplicateWords` it is also a performance improvement, going from O(n**2) to O(n).

The readability changes are quite subjective, I despise `reduce` which is why I consider these changes to be more legible, so consider these changes as proposals. I'm happy to revert one or more of these if you feel the originals are more in line with your current code style.