### PR TITLE
fix workout buttons in main action bar not working

### DIFF
--- a/apps/frontend/src/components/MainActionBar/SelectWorkoutButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/SelectWorkoutButton.tsx
@@ -1,10 +1,10 @@
 import { Icon, IconButton, Tooltip } from '@chakra-ui/react';
 import { BarChartLine, BarChartLineFill } from 'react-bootstrap-icons';
+import { useNavigate } from 'react-router-dom';
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
-import { useWorkoutEditorModal } from '../../context/ModalContext';
 
 export const SelectWorkoutButton = () => {
-  const { onOpen: onOpenWorkoutEditor } = useWorkoutEditorModal();
+  const navigate = useNavigate();
   const { activeWorkout } = useActiveWorkout();
 
   const text = activeWorkout.workout ? 'Change workout' : 'Select workout';
@@ -15,7 +15,7 @@ export const SelectWorkoutButton = () => {
         icon={
           <Icon as={activeWorkout.workout ? BarChartLineFill : BarChartLine} />
         }
-        onClick={onOpenWorkoutEditor}
+        onClick={() => navigate('/workout')}
       />
     </Tooltip>
   );

--- a/apps/frontend/src/components/MainActionBar/WorkoutControls.tsx
+++ b/apps/frontend/src/components/MainActionBar/WorkoutControls.tsx
@@ -18,6 +18,7 @@ import {
   SkipForwardFill,
   SkipStartFill,
 } from 'react-bootstrap-icons';
+import { useNavigate } from 'react-router-dom';
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
 import { useData } from '../../context/DataContext';
 import { useWorkoutEditorModal } from '../../context/ModalContext';
@@ -42,8 +43,8 @@ export const WorkoutControls = () => {
   const { activeWorkout, syncResistance, changeActivePart, pause, start } =
     useActiveWorkout();
   const { addLap } = useData();
-  const { onOpen: onOpenWorkoutEditor } = useWorkoutEditorModal();
   const linkColor = useLinkColor();
+  const navigate = useNavigate();
 
   const isWorkoutSelected = activeWorkout.workout !== null;
   const activeWorkoutPart = activeWorkout.activePart;
@@ -173,7 +174,7 @@ export const WorkoutControls = () => {
               <Button
                 variant="link"
                 color={linkColor}
-                onClick={() => onOpenWorkoutEditor()}
+                onClick={() => navigate('/workout')}
               >
                 Select workout
               </Button>


### PR DESCRIPTION
Didn't open the workout editor when clicked.

The "Select workout" button in the right action bar uses navigation for opening the workout modal, so I just copied that logic. I'm guessing routing was introduced for the modals at some point and these buttons were not migrated.

## Before
![2023-11-02 17 15 31](https://github.com/sivertschou/dundring/assets/25374940/0b61fcef-6855-4e67-a207-8471c62b7519)


## After
![2023-11-02 17 16 22](https://github.com/sivertschou/dundring/assets/25374940/741cc341-9516-4006-8299-30dbcf4eb266)
