### PR TITLE
Group minor and patch versions to lessen spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      non-major:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
This will make dependabots version bumping PRs group minor and patch bumps into a single PR, so that we don't get so many PRs about versions we don't care about.