### PR TITLE
Remove dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    groups:
-      non-major:
-        update-types:
-          - 'minor'
-          - 'patch'


### PR DESCRIPTION
The grouping made the merge of the PR feel more sketchy, since our test coverage is lacking. Removing this for now.