### PR TITLE
Add table mail authentication and migrate data

### DIFF
--- a/apps/backend/docker-entrypoint.sh
+++ b/apps/backend/docker-entrypoint.sh
@@ -3,7 +3,10 @@ set -e
 
 cd libs/database
 
-# Run the database migration
+# Run database schema migration
 yarn db:migrate
+
+# Run database data migrations
+node dist/migrate-data.cjs.js
 
 exec "$@"

--- a/libs/database/prisma/migrations/20240206170851_add_table_data_migration/migration.sql
+++ b/libs/database/prisma/migrations/20240206170851_add_table_data_migration/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "DataMigration" (
+    "name" TEXT NOT NULL,
+    "dateApplied" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DataMigration_name_key" ON "DataMigration"("name");

--- a/libs/database/prisma/migrations/20240206170929_add_table_mail_authentication/migration.sql
+++ b/libs/database/prisma/migrations/20240206170929_add_table_mail_authentication/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "MailAuthentication" (
+    "mail" TEXT NOT NULL,
+    "userId" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MailAuthentication_mail_key" ON "MailAuthentication"("mail");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MailAuthentication_userId_key" ON "MailAuthentication"("userId");
+
+-- AddForeignKey
+ALTER TABLE "MailAuthentication" ADD CONSTRAINT "MailAuthentication_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/libs/database/prisma/schema.prisma
+++ b/libs/database/prisma/schema.prisma
@@ -42,3 +42,8 @@ model SteadyWorkoutPart {
 
   @@unique([index, workoutId])
 }
+
+model DataMigration {
+  name        String   @unique
+  dateApplied DateTime @default(now())
+}

--- a/libs/database/prisma/schema.prisma
+++ b/libs/database/prisma/schema.prisma
@@ -11,11 +11,12 @@ datasource db {
 }
 
 model User {
-  id          String       @id @default(uuid())
-  username    String       @unique
-  mail        String       @unique
-  workouts    Workout[]
-  fitnessData FitnessData?
+  id                 String              @id @default(uuid())
+  username           String              @unique
+  mail               String              @unique
+  workouts           Workout[]
+  fitnessData        FitnessData?
+  mailAuthentication MailAuthentication?
 }
 
 model FitnessData {
@@ -41,6 +42,12 @@ model SteadyWorkoutPart {
   workoutId String
 
   @@unique([index, workoutId])
+}
+
+model MailAuthentication {
+  mail   String @unique
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id])
 }
 
 model DataMigration {

--- a/libs/database/rollup.config.js
+++ b/libs/database/rollup.config.js
@@ -1,16 +1,32 @@
 import typescript from '@rollup/plugin-typescript';
 
-export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: './dist/index.cjs.js',
-      format: 'cjs',
-    },
-    {
-      file: './dist/index.esm.js',
-      format: 'esm',
-    },
-  ],
-  plugins: [typescript()],
-};
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: './dist/index.cjs.js',
+        format: 'cjs',
+      },
+      {
+        file: './dist/index.esm.js',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+  {
+    input: 'src/migrate-data.ts',
+    output: [
+      {
+        file: './dist/migrate-data.cjs.js',
+        format: 'cjs',
+      },
+      {
+        file: './dist/migrate-data.esm.js',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/libs/database/src/migrate-data.ts
+++ b/libs/database/src/migrate-data.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const migrateAddTableMailAuthentication = async () => {
+  const migrationName = 'add_table_mail_authentication';
+  try {
+    await prisma.$transaction(async (tx) => {
+      const isMigrated = await tx.dataMigration.findUnique({
+        where: { name: migrationName },
+      });
+
+      if (isMigrated) {
+        console.info(`[${migrationName}]: data already migrated`);
+        return;
+      }
+
+      console.info(`[${migrationName}]: start migration`);
+
+      const users = await tx.user.findMany();
+
+      console.info(`[${migrationName}]: ${users.length} users found`);
+
+      await Promise.all(
+        users.map((user) =>
+          tx.mailAuthentication.create({
+            data: {
+              userId: user.id,
+              mail: user.mail,
+            },
+          })
+        )
+      );
+
+      console.info(`[${migrationName}]: add entry in DataMigration`);
+      await tx.dataMigration.create({ data: { name: migrationName } });
+    });
+
+    console.info(`[${migrationName}]: migration done`);
+  } catch (e) {
+    console.error(
+      `Something went wrong during data migration for '${migrationName}'`,
+      e
+    );
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+};
+
+export const migrate = async () => {
+  await migrateAddTableMailAuthentication();
+};
+migrate();


### PR DESCRIPTION
It was not straight forward how to do data migration with Prisma, but I think this is a kinda OK way of doing it. We're following the recommendations of Prisma, and based the code on [Prisma's docs on data migration](https://www.prisma.io/docs/orm/prisma-migrate/workflows/data-migration). Since we're the _expand and contract_ pattern, we're adding the new table, migrating the data and then we'll remove the `mail` row of the `User` table in a separate PR.

This PR is a part of the login refactoring. We're separating the `MailAuthentication` from the `User` model to be able to add multiple ways of authenticating, aka `StravaAuthentication` 👀 