### PR TITLE
Correct GPS preview

### DIFF
--- a/apps/frontend/src/components/Map/Map.tsx
+++ b/apps/frontend/src/components/Map/Map.tsx
@@ -3,13 +3,14 @@ import { useData } from '../../context/DataContext';
 import { Waypoint } from '../../types';
 import { powerColor } from '../../colors';
 import { useColorModeValue } from '@chakra-ui/react';
+import { toWebMercatorCoordinates } from '../../gps';
 
 export const Map = () => {
   const { data: laps, activeRoute } = useData();
   const dotStrokeColor = useColorModeValue('black', 'white');
   const rawData = laps.flatMap((x) => x.dataPoints);
 
-  const multiplier = 100;
+  const multiplier = 40;
 
   const dataPoints = rawData
     .map((dataPoint) => dataPoint.position)
@@ -52,7 +53,7 @@ export const Map = () => {
       <path
         fill="none"
         stroke="gray"
-        strokeWidth="0.01"
+        strokeWidth=".02"
         strokeLinejoin="round"
         strokeLinecap="round"
         d={`M ${routeCoordinates
@@ -63,7 +64,7 @@ export const Map = () => {
         <path
           fill="none"
           stroke={powerColor}
-          strokeWidth=".05"
+          strokeWidth=".03"
           strokeLinejoin="round"
           strokeLinecap="round"
           d={`M ${coordinates
@@ -74,7 +75,7 @@ export const Map = () => {
       {lastPoint ? (
         <g>
           <circle
-            r=".06"
+            r=".02"
             cx={lastPoint.x}
             cy={lastPoint.y}
             fill="white"
@@ -88,8 +89,7 @@ export const Map = () => {
 };
 
 const waypointsToSvgPoints = (waypoints: Waypoint[], multiplier = 1) =>
-  waypoints.map((waypoint) => ({
-    x: waypoint.lon * multiplier,
-    /* Negated to align Y axis */
-    y: -waypoint.lat * multiplier,
+  waypoints.map(toWebMercatorCoordinates).map((waypoint) => ({
+    x: waypoint.x * multiplier,
+    y: waypoint.y * multiplier,
   }));

--- a/apps/frontend/src/components/Map/Map.tsx
+++ b/apps/frontend/src/components/Map/Map.tsx
@@ -7,7 +7,8 @@ import { toWebMercatorCoordinates } from '../../gps';
 
 export const Map = () => {
   const { data: laps, activeRoute } = useData();
-  const dotStrokeColor = useColorModeValue('black', 'white');
+  const dotColor = useColorModeValue('black', 'white');
+  const routeColor = useColorModeValue('#bdbdbd', '#424242');
   const rawData = laps.flatMap((x) => x.dataPoints);
 
   const multiplier = 40;
@@ -52,8 +53,8 @@ export const Map = () => {
     <svg viewBox={viewBox}>
       <path
         fill="none"
-        stroke="gray"
-        strokeWidth=".02"
+        stroke={routeColor}
+        strokeWidth=".015"
         strokeLinejoin="round"
         strokeLinecap="round"
         d={`M ${routeCoordinates
@@ -78,8 +79,7 @@ export const Map = () => {
             r=".02"
             cx={lastPoint.x}
             cy={lastPoint.y}
-            fill="white"
-            stroke={dotStrokeColor}
+            fill={dotColor}
             strokeWidth="0.01px"
           />
         </g>

--- a/apps/frontend/src/gps.ts
+++ b/apps/frontend/src/gps.ts
@@ -75,3 +75,17 @@ export const dWaypoints: Waypoint[] =
       ...point,
       distance: haversine(point, arr[(index + 1) % arr.length]) * 1000,
     }));
+
+export const toWebMercatorCoordinates = (waypoint: Waypoint) => {
+  const zoom = 8;
+  return {
+    x:
+      (1 / (2 * Math.PI)) *
+      Math.pow(2, zoom) *
+      (Math.PI + toRadians(waypoint.lon)),
+    y:
+      (1 / (2 * Math.PI)) *
+      Math.pow(2, zoom) *
+      (Math.PI - Math.log(Math.tan(Math.PI / 4 + toRadians(waypoint.lat) / 2))),
+  };
+};


### PR DESCRIPTION
Googled around and found out that [Mercator projection](https://en.wikipedia.org/wiki/Mercator_projection) is used to flatten coordinates to make flat maps look good, so I tried running our paths through it and the results were nice 🤠 

| Before | After |
| ------ | ----- |
| <img width="1727" alt="image" src="https://github.com/sivertschou/dundring/assets/31168035/cf56214f-b251-4a70-be61-0fc13804c483"> | <img width="1727" alt="image" src="https://github.com/sivertschou/dundring/assets/31168035/53166b9a-2b0b-488e-bffd-3e3b475dd274"> |
| <img width="1727" alt="image" src="https://github.com/sivertschou/dundring/assets/31168035/2c305a9d-6483-42bb-858e-1b1bf1e155e5"> | <img width="1727" alt="image" src="https://github.com/sivertschou/dundring/assets/31168035/8f193783-7e5a-41ca-a6ee-a33e7103b8a5"> |
