### PR TITLE
Disable last workoutpart remove-button

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -251,6 +251,7 @@ export const WorkoutEditor = ({
               }}
               workoutPart={part}
               ftp={ftpValue}
+              isLastWorkoutPart={workout.parts.length === 1}
             />
           </DraggableItem>
         ))}

--- a/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
@@ -69,20 +69,11 @@ interface Props {
   setWorkoutPart: (workoutPart: WorkoutPart) => void;
   removeWorkoutPart: () => void;
   duplicateWorkoutPart: () => void;
+  isLastWorkoutPart: boolean;
   ftp: number;
 }
+
 export const templateColumns = '1fr 4fr 4fr 1fr 5fr 5fr 1fr 1fr 1fr';
-
-const calculateNewDuration = (minutesInput: string, secondsInput: string) => {
-  const minutesAsSeconds = parseInputAsInt(minutesInput) * 60;
-  const secondsAsSeconds = parseInputAsInt(secondsInput);
-
-  const duration = Math.max(minutesAsSeconds + secondsAsSeconds, 0);
-
-  const minutes = Math.floor(duration / 60);
-  const seconds = Math.floor(duration % 60);
-  return { duration, seconds, minutes };
-};
 
 export const WorkoutIntervalInput = ({
   setWorkoutPart,
@@ -90,6 +81,7 @@ export const WorkoutIntervalInput = ({
   duplicateWorkoutPart,
   workoutPart,
   ftp,
+  isLastWorkoutPart,
 }: Props) => {
   const updateWorkout = (
     data: Data,
@@ -319,10 +311,22 @@ export const WorkoutIntervalInput = ({
             aria-label="Remove interval"
             variant="ghost"
             onClick={removeWorkoutPart}
+            isDisabled={isLastWorkoutPart}
             icon={<Icon as={X} />}
           />
         </Center>
       </Tooltip>
     </Grid>
   );
+};
+
+const calculateNewDuration = (minutesInput: string, secondsInput: string) => {
+  const minutesAsSeconds = parseInputAsInt(minutesInput) * 60;
+  const secondsAsSeconds = parseInputAsInt(secondsInput);
+
+  const duration = Math.max(minutesAsSeconds + secondsAsSeconds, 0);
+
+  const minutes = Math.floor(duration / 60);
+  const seconds = Math.floor(duration % 60);
+  return { duration, seconds, minutes };
 };

--- a/libs/utils/src/workout.ts
+++ b/libs/utils/src/workout.ts
@@ -12,6 +12,6 @@ export const getTotalWorkoutDistance = (workout: Workout, ftp: number) => {
         ({ duration, targetPower }) =>
           duration * powerToSpeed[Math.round((targetPower * ftp) / 100)]
       )
-      .reduce((prev, cur) => prev + cur) / 1000
+      .reduce((prev, cur) => prev + cur, 0) / 1000
   );
 };


### PR DESCRIPTION
* Disables the remove-button for a workout part if it is the last, because a workout has to have one part
* Adds 0 as the initival value to the getTotalWorkoutDistance (which was the cause of the original bug/crash), to prevent crashes in the future


Fixes this bug:
![2024-03-20 20 19 01](https://github.com/sivertschou/dundring/assets/21218279/130bdac5-26f0-4c76-a5ec-090954bef37f)



After this pr:
![2024-03-20 22 19 48](https://github.com/sivertschou/dundring/assets/21218279/c8e692b0-c658-4489-9c99-837570367360)


