### PR TITLE
Fix logs modal and breaking support text

### DIFF
--- a/apps/frontend/src/components/BottomBar.tsx
+++ b/apps/frontend/src/components/BottomBar.tsx
@@ -16,7 +16,7 @@ import { MainActionBar } from './MainActionBar';
 import { Link as ReachLink, useNavigate } from 'react-router-dom';
 import { useColorMode, useColorModeValue } from '@chakra-ui/color-mode';
 import { useLogs } from '../context/LogContext';
-import { Icon } from '@chakra-ui/react';
+import { Icon, useBreakpointValue } from '@chakra-ui/react';
 import { githubRepo, slackInvite } from '../links';
 
 export const BottomBar = () => {
@@ -29,6 +29,10 @@ export const BottomBar = () => {
     ? 'Toggle light mode'
     : 'Toggle dark mode';
 
+  const helpText = useBreakpointValue({
+    base: 'Support',
+    md: 'Support & feedback',
+  });
   const navigate = useNavigate();
 
   const now = new Date();
@@ -44,7 +48,7 @@ export const BottomBar = () => {
         <Grid
           backgroundColor={bgColor}
           width="100%"
-          templateColumns="1fr 2fr 1fr"
+          templateColumns="2fr 3fr 2fr"
           pointerEvents="auto"
         >
           <Flex p="1">
@@ -61,6 +65,7 @@ export const BottomBar = () => {
               textAlign="center"
               opacity={lastMessageShouldBeVisible ? 100 : 0}
               transition="opacity 0.5s ease"
+              fontSize="xs"
             >
               {loggedEvents[0] ? `${loggedEvents[0].msg}` : null}
             </Text>
@@ -68,7 +73,7 @@ export const BottomBar = () => {
           <HStack justifyContent="flex-end" paddingX="2">
             <Center></Center>
             <Link as={ReachLink} to="/feedback">
-              <Text fontSize="xs">Need help or have feedback?</Text>
+              <Text fontSize="xs">{helpText}</Text>
             </Link>
             <Center>
               <Tooltip label={colorModeButtonText}>

--- a/apps/frontend/src/components/BottomBar.tsx
+++ b/apps/frontend/src/components/BottomBar.tsx
@@ -13,9 +13,8 @@ import { useAvailability } from '../hooks/useAvailability';
 import { Logo } from './Logo';
 import { Github, MoonFill, Slack, SunFill } from 'react-bootstrap-icons';
 import { MainActionBar } from './MainActionBar';
-import { Link as ReachLink } from 'react-router-dom';
+import { Link as ReachLink, useNavigate } from 'react-router-dom';
 import { useColorMode, useColorModeValue } from '@chakra-ui/color-mode';
-import { useLogModal } from '../context/ModalContext';
 import { useLogs } from '../context/LogContext';
 import { Icon } from '@chakra-ui/react';
 import { githubRepo, slackInvite } from '../links';
@@ -23,13 +22,14 @@ import { githubRepo, slackInvite } from '../links';
 export const BottomBar = () => {
   const { colorMode, setColorMode } = useColorMode();
   const { available: bluetoothIsAvailable } = useAvailability();
-  const { onOpen } = useLogModal();
   const { loggedEvents } = useLogs();
   const bgColor = useColorModeValue('gray.200', 'gray.900');
   const isDarkmode = colorMode !== 'light';
   const colorModeButtonText = isDarkmode
     ? 'Toggle light mode'
     : 'Toggle dark mode';
+
+  const navigate = useNavigate();
 
   const now = new Date();
   const lastMessageShouldBeVisible =
@@ -52,7 +52,11 @@ export const BottomBar = () => {
               <Logo height="20px" />
             </Link>
           </Flex>
-          <Button variant="link" fontWeight="normal" onClick={onOpen}>
+          <Button
+            variant="link"
+            fontWeight="normal"
+            onClick={() => navigate('/logs')}
+          >
             <Text
               textAlign="center"
               opacity={lastMessageShouldBeVisible ? 100 : 0}


### PR DESCRIPTION
The logs modal could not be opened due to the `navigate`-rework a while back. I don't necessarily think this feature is too important, and I think we could rework how these kinds of events should be displayed, if they should be displayed at all 👀 

+Fix breaking support text

| Before | After |
| ------ | ----- |
| ![2024-03-23 09 06 44](https://github.com/sivertschou/dundring/assets/31168035/46b7d38d-11fa-42d8-b84a-1a38ebfdfa9c) | ![2024-03-23 09 05 39](https://github.com/sivertschou/dundring/assets/31168035/0965d0b1-7b6c-4ccc-a82e-219a9fb527fa) |
| ![2024-03-23 09 09 33](https://github.com/sivertschou/dundring/assets/31168035/0acf7fd8-b716-44b1-ae6d-f7ff74eb5cda) | ![2024-03-23 09 09 52](https://github.com/sivertschou/dundring/assets/31168035/55f7f4b2-1976-46d3-a14d-9c54d586b1db) |


