### PR TITLE
Fix discard bug : set unsaved false after using-without-save

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutEditor.tsx
@@ -308,6 +308,7 @@ export const WorkoutEditor = ({
           <Button
             onClick={() => {
               setActiveWorkout(workout);
+              setIsWorkoutUnsaved(false);
               closeEditor();
               closeModal();
             }}


### PR DESCRIPTION
Fixes "discard changes" bug , where it would pop up warning after going to workout selector after"use workout without saving", f.ex. to change active Ftp.
There are no changes to discard in this scenario, so it should be set to false after using the unsaved workout.

Current:
![2024-03-27 20 20 23](https://github.com/sivertschou/dundring/assets/21218279/0d342ebe-3e88-4457-8a0a-fdf8f75c2fd2)


This PR:
![2024-03-27 20 19 57](https://github.com/sivertschou/dundring/assets/21218279/6511929c-b6b6-47a6-aa01-e8f05ba5ec39)
