### PR TITLE
Change clock worker to tick every second

### DIFF
--- a/apps/frontend/src/workers/clock.worker.js
+++ b/apps/frontend/src/workers/clock.worker.js
@@ -23,7 +23,7 @@ export default () => {
             delta: Date.now() - lastDataTick,
           });
           lastDataTick = Date.now();
-        }, 500);
+        }, 1000);
         break;
       }
       case 'stopDataTimer': {


### PR DESCRIPTION
Strava has issues with our tcx-files because we have 2 data points every second.
Strava then gets tripped up (and quite embarrasingly) 

* Zone count, the time in each zone is twice the real amount. (and is then more than the actual elapsed time): 
![image](https://github.com/user-attachments/assets/7d7581f1-ff75-49c6-b83e-e8344aa00a4f)
* Best effort wattage - duration is double
![image](https://github.com/user-attachments/assets/b2fdbba7-6f0e-494a-a055-b16ccef41bbc)
![image](https://github.com/user-attachments/assets/043cb165-0f06-4dea-94f7-b99d50d07b29)

I can come up with 2 solutions for this:
Either
change from dataTick every 1000ms instead of 500ms. 
or 
just the extra datapoints when creating the tcx.

I think changing the dataTick (this pr), is the easiest.

Any reasons not to change?