### PR TITLE
Fix import-workout-link parsing

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/ImportWorkout.tsx
@@ -11,7 +11,7 @@ import {
 import { getWorkout } from '../../api';
 import { Text } from '@chakra-ui/layout';
 import { WorkoutToEdit } from '../Modals/WorkoutEditorModal';
-import { useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import * as api from '../../api';
 
@@ -27,7 +27,8 @@ interface Props {
 }
 
 export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
-  const { workoutId: workoutIdParam } = useParams();
+  const location = useLocation();
+  const workoutIdParam = parseWorkoutIdFromPath(location.pathname);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [workoutIdInput, setWorkoutIdInput] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
@@ -114,4 +115,9 @@ export const ImportWorkout = ({ setWorkoutToEdit, previewFtp }: Props) => {
       </FormControl>
     </form>
   );
+};
+
+const parseWorkoutIdFromPath = (pathname: string) => {
+  const match = pathname.match(/\/workout\/([0-9a-fA-F-]{36})/);
+  return match ? match[1] : null;
 };


### PR DESCRIPTION
Currently it only redirects to the workout editor, since it ignores the UUID-path param.
This has probably been broken since : https://github.com/sivertschou/dundring/commit/8b2af524e35c80af2a822a42eb58e79b80fc8fed

Since the routing stuff is restructered, this is the easiest way I could think of to fix it.

Test-link: https://preview-382.dundring.com/workout/7baa6a1c-63cc-43ff-a15e-369924d1b0b9

This pr:
![2024-08-28 21 45 56](https://github.com/user-attachments/assets/652f7695-419d-4718-86dd-12e968215fff)

