### PR TITLE
Average watt for free mode

### DIFF
--- a/apps/frontend/src/components/TopBar.tsx
+++ b/apps/frontend/src/components/TopBar.tsx
@@ -10,23 +10,29 @@ import {
   useActiveWorkout,
 } from '../context/ActiveWorkoutContext';
 import { secondsToHoursMinutesAndSecondsString } from '@dundring/utils';
+import { Lap } from '../types';
+
+const mainFontSize = ['xl', '3xl', '7xl'];
+const unitFontSize = ['l', '2xl', '4xl'];
+const secondaryFontSize = ['m', 'xl', '2xl'];
 
 export const TopBar = () => {
   const { cadence, currentResistance } = useSmartTrainer();
   const { heartRate } = useHeartRateMonitor();
   const { activeWorkout } = useActiveWorkout();
-  const { timeElapsed, distance, speed, smoothedPower } = useData();
+  const { data: laps, timeElapsed, distance, speed, smoothedPower } = useData();
   const remainingTime = getRemainingTime(activeWorkout);
 
   const secondsElapsed = Math.floor(timeElapsed / 1000);
 
-  const mainFontSize = ['xl', '3xl', '7xl'];
-  const unitFontSize = ['l', '2xl', '4xl'];
-  const secondaryFontSize = ['m', 'xl', '2xl'];
   const bgColor = useColorModeValue(theme.colors.white, theme.colors.gray[800]);
   const textShadow = `0px 0px 1vh ${bgColor}`;
 
   const flooredDistance = Math.floor(distance / 100) / 10;
+
+  const isFreeMode = !currentResistance;
+
+  const currentLap = laps.at(-1) || null;
 
   return (
     <Center
@@ -75,17 +81,32 @@ export const TopBar = () => {
             </Stack>
             <Stack spacing="0" color={powerColor}>
               <Text fontSize={secondaryFontSize}>
-                {currentResistance > 0 ? `@${currentResistance}w` : 'Free mode'}
+                {!isFreeMode ? `@${currentResistance}w` : 'Free mode'}
               </Text>
               <Center>
                 <Text fontSize={mainFontSize}>{smoothedPower || '0'}</Text>
                 <Text fontSize={unitFontSize}>w</Text>
               </Center>
+              {isFreeMode && <AvgWattText currentLap={currentLap} />}
+
               <Text fontSize={secondaryFontSize}>{cadence || '0'} rpm</Text>
             </Stack>
           </Grid>
         </Center>
       </Stack>
     </Center>
+  );
+};
+
+const AvgWattText = (props: { currentLap: Lap | null }) => {
+  const { currentLap } = props;
+  if (!currentLap?.normalizedDuration) {
+    return null;
+  }
+  return (
+    <Text fontSize={secondaryFontSize}>
+      Lap avg:
+      {(currentLap.sumWatt / currentLap.normalizedDuration).toFixed(0)}W
+    </Text>
   );
 };

--- a/apps/frontend/src/context/ActiveWorkoutContext.tsx
+++ b/apps/frontend/src/context/ActiveWorkoutContext.tsx
@@ -84,10 +84,16 @@ export const ActiveWorkoutContextProvider = ({
           partElapsedTime: 0,
         };
       case 'INCREASE_PART_ELAPSED_TIME':
-        if (!activeWorkout.workout || activeWorkout.status !== 'active')
+        if (activeWorkout.status !== 'active') {
           return activeWorkout;
+        }
 
         const newElapsed = action.millis + activeWorkout.partElapsedTime;
+
+        if (!activeWorkout.workout) {
+          return { ...activeWorkout, partElapsedTime: newElapsed };
+        }
+
         const elapsedSeconds = Math.floor(newElapsed / 1000);
         const prevActivePart = activeWorkout.activePart;
         const prevWorkoutParts = activeWorkout.workout.parts;
@@ -130,7 +136,11 @@ export const ActiveWorkoutContextProvider = ({
         action.addLap();
 
         if (action.partNumber >= activeWorkout.workout.parts.length) {
-          return { ...activeWorkout, partElapsedTime: 0, status: 'finished' };
+          return {
+            ...activeWorkout,
+            partElapsedTime: 0,
+            status: 'finished',
+          };
         }
 
         return {

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -1,6 +1,8 @@
 export interface Lap {
   dataPoints: DataPoint[];
   distance: number;
+  sumWatt: number;
+  normalizedDuration: number;
 }
 export interface DataPoint {
   heartRate?: number;


### PR DESCRIPTION
Calculate avg watt for each lap and display it in the top bar when in free mode.
Design is up for improvement, as always.

Could also maybe put this data (along with distance) in a `aggregatedInfo` or something for each lap.
Will probably something similar for for HR also, and avoid bloating the original data struct too much.

![2024-09-19 22 57 34](https://github.com/user-attachments/assets/4084cc46-8f0d-4eef-96d3-9f8fe690f1ff)

Not shown for ergmode

![2024-09-19 22 58 13](https://github.com/user-attachments/assets/755c5f4f-0c87-4d84-8634-36a8230c1912)
