### PR TITLE
Fix strava auth - update refresh token bug

### DIFF
--- a/apps/backend/src/routes/auth/strava.ts
+++ b/apps/backend/src/routes/auth/strava.ts
@@ -30,12 +30,15 @@ router.post<
 
   const stravaId = tokenData.data.athlete.id;
 
-  await stravaService.updateRefreshToken({
-    athleteId: stravaId,
-    refreshToken: tokenData.data.refresh_token,
-  });
-
   const existingUser = await userService.getUserByStravaId(stravaId);
+
+  const updateRefreshTokenAndGiveExistingUser = async () => {
+    await stravaService.updateRefreshToken({
+      athleteId: stravaId,
+      refreshToken: tokenData.data.refresh_token,
+    });
+    return existingUser;
+  };
 
   const user =
     isError(existingUser) && existingUser.type === 'User not found'
@@ -44,7 +47,7 @@ router.post<
           refreshToken: tokenData.data.refresh_token,
           scopes: [],
         })
-      : existingUser;
+      : await updateRefreshTokenAndGiveExistingUser();
 
   if (isSuccess(user)) {
     const username = user.data.username;


### PR DESCRIPTION
The code tries to update the user before it is created. leading to an error. This error is ignored, and only logged, so it works. but better to skip it and only do it when needed

```
@dundring/backend:dev: [db.updateStravaRefreshToken]: PrismaClientKnownRequestError:
@dundring/backend:dev: Invalid `prisma.stravaAuthentication.update()` invocation in
@dundring/backend:dev: /Users/mortenkolstad/dundring/apps/backend/src/db.ts:443:54
@dundring/backend:dev:
@dundring/backend:dev:   440   Status<StravaAuthentication, 'Something went wrong while writing to database'>
@dundring/backend:dev:   441 > => {
@dundring/backend:dev:   442   try {
@dundring/backend:dev: → 443     const result = await prisma.stravaAuthentication.update(
@dundring/backend:dev: An operation failed because it depends on one or more records that were required but not found. Record to update not found.
```