### PR TITLE
Add 3 second smoothing to top bar-power

### DIFF
--- a/apps/frontend/src/components/TopBar.tsx
+++ b/apps/frontend/src/components/TopBar.tsx
@@ -12,10 +12,10 @@ import {
 import { secondsToHoursMinutesAndSecondsString } from '@dundring/utils';
 
 export const TopBar = () => {
-  const { power, cadence, currentResistance } = useSmartTrainer();
+  const { cadence, currentResistance } = useSmartTrainer();
   const { heartRate } = useHeartRateMonitor();
   const { activeWorkout } = useActiveWorkout();
-  const { timeElapsed, distance, speed } = useData();
+  const { timeElapsed, distance, speed, smoothedPower } = useData();
   const remainingTime = getRemainingTime(activeWorkout);
 
   const secondsElapsed = Math.floor(timeElapsed / 1000);
@@ -78,7 +78,7 @@ export const TopBar = () => {
                 {currentResistance > 0 ? `@${currentResistance}w` : 'Free mode'}
               </Text>
               <Center>
-                <Text fontSize={mainFontSize}>{power || '0'}</Text>
+                <Text fontSize={mainFontSize}>{smoothedPower || '0'}</Text>
                 <Text fontSize={unitFontSize}>w</Text>
               </Center>
               <Text fontSize={secondaryFontSize}>{cadence || '0'} rpm</Text>


### PR DESCRIPTION
No smoothing for free-mode is a bit annoying.
This now shows 3 second smoothing instead.

Two points of notice:
* This now also smoothens poweroutput for ergmod. we could instead check if targetResistance > 0 and just show power.
But i dont think it matters. 
* The smoothing will reset for every new lap, meaning that second 1 of a new lap will just show the 1 second power, and same for 2. I think this is fine. But could ofc have a check for lap.dataPoints length and then try to get the last datapoints from previous lap, if needed.
* This doesn't smooth in when not_started / pause, since this is not stored in the laps. Could have a check for status and then use untracked points instead, but some edge case when switching and such