### PR TITLE
Add mocking-control to window from console

### DIFF
--- a/apps/frontend/src/context/HeartRateContext.tsx
+++ b/apps/frontend/src/context/HeartRateContext.tsx
@@ -4,53 +4,32 @@ import {
   useHeartRateMonitorInterface,
 } from '../hooks/useHeartRateMonitorInterface';
 import { useHeartRateMonitorMock } from '../hooks/useHeartRateMonitorMock';
+import { useMockSettings } from './MockContext';
 
 const HeartRateContext = React.createContext<HeartRateMonitorInterface | null>(
   null
 );
-
-export const HeartRateRealContextProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const heartRateMonitor = useHeartRateMonitorInterface();
-
-  return (
-    <HeartRateContext.Provider value={heartRateMonitor}>
-      {children}
-    </HeartRateContext.Provider>
-  );
-};
-
-export const HeartRateMockContextProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const heartRateMonitor = useHeartRateMonitorMock();
-
-  return (
-    <HeartRateContext.Provider value={heartRateMonitor}>
-      {children}
-    </HeartRateContext.Provider>
-  );
-};
 
 export const HeartRateContextProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const usingMockData = import.meta.env.VITE_USE_MOCK_DATA ? true : false;
+  const { mocking } = useMockSettings();
+  const heartRateMonitor = useHeartRateMonitorInterface();
+  const mockHeartRateMonitor = useHeartRateMonitorMock();
 
-  if (usingMockData) {
+  if (mocking) {
     return (
-      <HeartRateMockContextProvider>{children}</HeartRateMockContextProvider>
+      <HeartRateContext.Provider value={mockHeartRateMonitor}>
+        {children}
+      </HeartRateContext.Provider>
     );
   } else {
     return (
-      <HeartRateRealContextProvider>{children}</HeartRateRealContextProvider>
+      <HeartRateContext.Provider value={heartRateMonitor}>
+        {children}
+      </HeartRateContext.Provider>
     );
   }
 };

--- a/apps/frontend/src/context/MockContext.tsx
+++ b/apps/frontend/src/context/MockContext.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+declare global {
+  interface Window {
+    setMock: (b?: boolean) => void;
+    mockHr: number | null;
+    mockWatt: number | null;
+  }
+}
+
+const mockingOnFromEnvironment =
+  import.meta.env.VITE_USE_MOCK_DATA === 'true' ||
+  import.meta.env.VITE_USE_MOCK_DATA === 'TRUE' ||
+  false;
+
+const MockContext = React.createContext<{
+  mocking: boolean;
+} | null>({
+  mocking: mockingOnFromEnvironment,
+});
+
+export const MockProvider = ({ children }: { children: React.ReactNode }) => {
+  const [mocking, setMocking] = React.useState(false);
+  React.useEffect(() => {
+    window.setMock = (b: any) => {
+      if (b === undefined) {
+        setMocking(true);
+      }
+      if (typeof b === 'boolean') {
+        setMocking(b);
+      }
+    };
+  }, [mocking]);
+
+  return (
+    <MockContext.Provider value={{ mocking }}>{children}</MockContext.Provider>
+  );
+};
+
+export function useMockSettings() {
+  const context = React.useContext(MockContext);
+  if (context === null) {
+    throw new Error(
+      'useSmartTrainer must be used within a SmartTrainerContextProvider'
+    );
+  }
+  return context;
+}

--- a/apps/frontend/src/context/SmartTrainerContext.tsx
+++ b/apps/frontend/src/context/SmartTrainerContext.tsx
@@ -4,45 +4,28 @@ import {
   useSmartTrainerInterface,
 } from '../hooks/useSmartTrainerInterface';
 import { useSmartTrainerMock } from '../hooks/useSmartTrainerMock';
+import { useMockSettings } from './MockContext';
 
 const SmartTrainerContext = React.createContext<SmartTrainerInterface | null>(
   null
 );
-
-export const SmartTrainerRealContextProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const smartTrainer = useSmartTrainerInterface();
-
-  return (
-    <SmartTrainerContext.Provider value={smartTrainer} children={children} />
-  );
-};
-
-export const SmartTrainerMockContextProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const smartTrainer = useSmartTrainerMock();
-
-  return (
-    <SmartTrainerContext.Provider value={smartTrainer} children={children} />
-  );
-};
 
 export const SmartTrainerContextProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const usingMockData = import.meta.env.VITE_USE_MOCK_DATA ? true : false;
-
-  if (usingMockData)
-    return <SmartTrainerMockContextProvider children={children} />;
-  return <SmartTrainerRealContextProvider children={children} />;
+  const { mocking } = useMockSettings();
+  const mockTrainer = useSmartTrainerMock();
+  const smartTrainer = useSmartTrainerInterface();
+  if (mocking) {
+    return (
+      <SmartTrainerContext.Provider value={mockTrainer} children={children} />
+    );
+  }
+  return (
+    <SmartTrainerContext.Provider value={smartTrainer} children={children} />
+  );
 };
 
 export const useSmartTrainer = () => {

--- a/apps/frontend/src/hooks/useHeartRateMonitorMock.ts
+++ b/apps/frontend/src/hooks/useHeartRateMonitorMock.ts
@@ -11,9 +11,13 @@ export const useHeartRateMonitorMock = (): HeartRateMonitorInterface => {
   React.useEffect(() => {
     const interval = setInterval(() => {
       if (isConnected) {
-        setHeartRate((prev) =>
-          randomIntFromIntervalBasedOnPrev(130, 150, prev, 5)
-        );
+        if (window.mockHr !== null) {
+          setHeartRate(window.mockHr);
+        } else {
+          setHeartRate((prev) =>
+            randomIntFromIntervalBasedOnPrev(130, 150, prev, 5)
+          );
+        }
       }
     }, 1000);
     return () => clearInterval(interval);

--- a/apps/frontend/src/hooks/useSmartTrainerMock.ts
+++ b/apps/frontend/src/hooks/useSmartTrainerMock.ts
@@ -19,7 +19,9 @@ export const useSmartTrainerMock = (): SmartTrainerInterface => {
           randomIntFromIntervalBasedOnPrev(80, 100, prev, 5)
         );
 
-        if (targetPower) {
+        if (window.mockWatt !== null) {
+          setPower(window.mockWatt);
+        } else if (targetPower) {
           setPower((prev) =>
             randomIntFromIntervalBasedOnPrev(
               targetPower,

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -14,6 +14,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ModalContextProvider } from './context/ModalContext';
 import { DataContextProvider } from './context/DataContext';
 import { ActiveWorkoutContextProvider } from './context/ActiveWorkoutContext';
+import { MockProvider } from './context/MockContext';
 
 const cw: Worker = new WorkerBuilder(clockWorker);
 cw.postMessage('startDataTimer');
@@ -26,20 +27,22 @@ root.render(
       <BrowserRouter>
         <LogContextProvider>
           <UserContextProvider>
-            <HeartRateContextProvider>
-              <SmartTrainerContextProvider>
-                <ActiveWorkoutContextProvider>
-                  <WebsocketContextProvider>
-                    <DataContextProvider clockWorker={cw}>
-                      <ModalContextProvider>
-                        <ColorModeScript />
-                        <App />
-                      </ModalContextProvider>
-                    </DataContextProvider>
-                  </WebsocketContextProvider>
-                </ActiveWorkoutContextProvider>
-              </SmartTrainerContextProvider>
-            </HeartRateContextProvider>
+            <MockProvider>
+              <HeartRateContextProvider>
+                <SmartTrainerContextProvider>
+                  <ActiveWorkoutContextProvider>
+                    <WebsocketContextProvider>
+                      <DataContextProvider clockWorker={cw}>
+                        <ModalContextProvider>
+                          <ColorModeScript />
+                          <App />
+                        </ModalContextProvider>
+                      </DataContextProvider>
+                    </WebsocketContextProvider>
+                  </ActiveWorkoutContextProvider>
+                </SmartTrainerContextProvider>
+              </HeartRateContextProvider>
+            </MockProvider>
           </UserContextProvider>
         </LogContextProvider>
       </BrowserRouter>


### PR DESCRIPTION
This enables us to enable and control mocking of HR and Power in dev and prod, without having to have multiple builds or pages.
This is done through adding function and fields to `window`.
Using `window` too much can be a bit shady, but these values are not exposing any private data or something like that.
The worst that can happen is that the page crashes or some data gets weird.

Commands:
## setMock
Turns on or disables mocking
* window.setMock(), setMock(true) => enables mocking
* window.setMock(false) => disables mocking
* window.setMock(non-undefined nonBoolean) => ignored

## mockHr (and same for mockWatt)
Gives possibility to control the mocking to specific values. These values will not be used unless mocking is turned on.
* window.mockHr = number => hr mock is set to give number as current HR
* window.mockHr = null => hr mock is back to default mocking mode
* window.mockHr = something weird => crash / weird behaviour , but can't see how it should be anything seriously bad

