### PR TITLE
Remove .com from strava-default-activity name

### DIFF
--- a/apps/backend/src/routes/me/index.ts
+++ b/apps/backend/src/routes/me/index.ts
@@ -62,7 +62,7 @@ router.post<any, ApiResponseBody<StravaUpload>>(
       });
     }
     const fileContent = req.file.buffer.toString();
-    const activityName = (req.query.name || 'dundring.com workout') as string;
+    const activityName = (req.query.name || 'dundring') as string;
 
     if (!validationService.authenticateToken(req, res)) {
       return;


### PR DESCRIPTION
Strava has started to <censor> link-ish names, like dundring.com. So we should avoid it