### PR TITLE
Don't reset watt when starting

### DIFF
--- a/apps/frontend/src/context/ActiveWorkoutContext.tsx
+++ b/apps/frontend/src/context/ActiveWorkoutContext.tsx
@@ -169,7 +169,9 @@ export const ActiveWorkoutContextProvider = ({
     const status = activeWorkout.status;
     const workout = activeWorkout.workout;
 
-    if (status !== 'active' || !workout) {
+    if (status === 'active' && !workout) {
+      return;
+    } else if (status !== 'active' || !workout) {
       setResistance(0);
     } else {
       const activeWorkoutPart = workout.parts[activeWorkout.activePart];


### PR DESCRIPTION
Don't reset watt to 0/FreeMode when pressing start with no active workout.

Fixes confusing case: 
I want to ride ~1 hour at 180W. 
I connect my trainer.
I set my watt to 180W.
I click start.
My watt target is changed to Free mode?

## Current prod - resets
![2024-10-13 11 25 03](https://github.com/user-attachments/assets/446e5cab-a46d-4767-af91-b3712e47963d)

## This PR - no reset
![2024-10-13 11 25 39](https://github.com/user-attachments/assets/0e9b99f8-bafc-42c6-9833-34c5baf6d168)

