### PR TITLE
Fix useMockSettings default value

### DIFF
--- a/apps/frontend/src/context/MockContext.tsx
+++ b/apps/frontend/src/context/MockContext.tsx
@@ -8,19 +8,17 @@ declare global {
   }
 }
 
-const mockingOnFromEnvironment =
-  import.meta.env.VITE_USE_MOCK_DATA === 'true' ||
-  import.meta.env.VITE_USE_MOCK_DATA === 'TRUE' ||
-  false;
-
 const MockContext = React.createContext<{
   mocking: boolean;
-} | null>({
-  mocking: mockingOnFromEnvironment,
-});
+} | null>(null);
 
 export const MockProvider = ({ children }: { children: React.ReactNode }) => {
-  const [mocking, setMocking] = React.useState(false);
+  const mockingOnFromEnvironment =
+    import.meta.env.VITE_USE_MOCK_DATA === 'true' ||
+    import.meta.env.VITE_USE_MOCK_DATA === 'TRUE' ||
+    false;
+
+  const [mocking, setMocking] = React.useState(mockingOnFromEnvironment);
   React.useEffect(() => {
     window.toggleMock = () => {
       setMocking((prev) => !prev);


### PR DESCRIPTION
The useMockSettings had false as default for `useState`, which stopped `yarn mock` from working correctly. 
It basically ignored the VITE_USE_MOCK_DATA.

The defaultValue in the Context should actually be null, to avoid it being used outside of the context. 
(I guess it can be false without much harm, but should probably just be null and throw, like the rest of the contexts)