### PR TITLE
Add .zwo-upload

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.11.0",
+    "@rgrove/parse-xml": "^4.1.0",
     "@svgr/webpack": "^8.1.0",
     "babel-plugin-named-asset-import": "^0.3.8",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",

--- a/apps/frontend/src/components/WorkoutMenu/WorkoutOverview.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutOverview.tsx
@@ -19,6 +19,7 @@ import { ImportWorkout } from './ImportWorkout';
 import { WorkoutListItem } from './WorkoutListItem';
 import { useData } from '../../context/DataContext';
 import { stringToRouteName } from '../../gps';
+import ZwoFileUpload from '../ZwoFileUpload';
 
 interface Props {
   setActiveWorkout: (workout: Workout, ftp: number) => void;
@@ -147,6 +148,11 @@ export const WorkoutOverview = ({
           ftp={previewFtpAsNumber}
         />
       ))}
+      <Divider />
+      <ZwoFileUpload
+        setWorkoutToEdit={setWorkoutToEdit}
+        previewFtp={previewFtpAsNumber}
+      />
       <Divider />
       <ImportWorkout
         setWorkoutToEdit={setWorkoutToEdit}

--- a/apps/frontend/src/components/ZwoFileUpload.tsx
+++ b/apps/frontend/src/components/ZwoFileUpload.tsx
@@ -1,0 +1,81 @@
+import React, { ChangeEvent } from 'react';
+import { WorkoutToEdit } from './Modals/WorkoutEditorModal';
+import { Center, Input, Tooltip, useToast } from '@chakra-ui/react';
+import { parseZwoWorkout } from '../utils/ZwoParsing';
+import { Stack } from '@chakra-ui/layout';
+import { Button } from '@chakra-ui/button';
+
+interface Props {
+  previewFtp: number;
+  setWorkoutToEdit: (workout: WorkoutToEdit) => void;
+}
+
+const ZwoFileUpload = ({ setWorkoutToEdit, previewFtp }: Props) => {
+  const toast = useToast();
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const reader = new FileReader();
+
+    reader.onload = (fileReaderEvent: ProgressEvent<FileReader>) => {
+      const fileInput = fileReaderEvent.target?.result;
+      if (typeof fileInput !== 'string') {
+        toast({
+          title: 'Importing workout failed',
+          description:
+            'The file is either invalid or contains event types that are not supported',
+          isClosable: true,
+          duration: 10000,
+          status: 'error',
+        });
+        return;
+      }
+      const parsedWorkout = parseZwoWorkout(fileInput);
+      const workout = parsedWorkout.workout;
+      if (workout) {
+        setWorkoutToEdit({ ...workout, type: 'new', previewFtp });
+      }
+
+      if (parsedWorkout.errors.size > 0) {
+        toast({
+          title: 'Something went wrong when parsing .zwo file',
+          description: Array.from(parsedWorkout.errors).join('\n'),
+          isClosable: true,
+          duration: 10000,
+          status: workout ? 'warning' : 'error',
+        });
+      }
+    };
+    if (!event.target.files) {
+      console.error('Internal error: Missing files in upload');
+      return;
+    }
+    reader.readAsText(event.target.files[0]);
+  };
+
+  return (
+    <Stack>
+      <Center>
+        <label htmlFor="file-input" className="custom-file-label">
+          <Tooltip
+            label={
+              'This feature is in Beta. You should check that the resulting workout corresponds to what you expect.\nIf you get an error, you can check the console for more information'
+            }
+          >
+            <Button as="span" cursor="pointer">
+              Import workout from .zwo file (Beta)
+            </Button>
+          </Tooltip>
+        </label>
+        <Input
+          id="file-input"
+          type="file"
+          onChange={handleFileChange}
+          accept=".zwo"
+          hidden={true} // Hidden because the label-element acts as a styled input
+        />
+      </Center>
+    </Stack>
+  );
+};
+
+export default ZwoFileUpload;

--- a/apps/frontend/src/utils/ZwoParsing.ts
+++ b/apps/frontend/src/utils/ZwoParsing.ts
@@ -1,0 +1,235 @@
+import { parseXml, XmlDocument, XmlElement, XmlText } from '@rgrove/parse-xml';
+import { Workout, WorkoutPart } from '../types';
+
+export const parseZwoWorkout = (
+  str: string
+): { workout: Workout | null; errors: Set<string> } => {
+  try {
+    const xmlDocument: XmlDocument = parseXml(str);
+    const workoutFileElement = xmlDocument.children[0];
+    if (!isXmlElement(workoutFileElement)) {
+      return {
+        workout: null,
+        errors: new Set([`Invalid ZWO-file: Missing children-element`]),
+      };
+    }
+    const zwoWorkout = parseWorkoutFile(workoutFileElement);
+    return {
+      workout: zwoWorkout.workout
+        ? zwoWorkoutToDundringWorkout(zwoWorkout.workout)
+        : null,
+      errors: zwoWorkout.errors,
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      workout: null,
+      errors: new Set([`Invalid ZWO-file: ${err}`]),
+    };
+  }
+};
+
+type ZwoWorkout = {
+  name: string;
+  parts: Array<ZwoWorkoutPart>;
+};
+
+type ZwoWorkoutPart = SteadyState | IntervalsT | FreeRide | Warmup | Cooldown;
+
+type SteadyState = { type: 'steadystate'; duration: number; power: number };
+
+type IntervalsT = {
+  type: 'intervals';
+  repeat: number;
+  onDuration: number;
+  offDuration: number;
+  onPower: number;
+  offPower: number;
+};
+
+type FreeRide = { type: 'freeride'; duration: number };
+
+type Warmup = {
+  type: 'warmup' | 'ramp';
+  duration: number;
+  powerLow: number;
+  powerHigh: number;
+};
+
+type Cooldown = {
+  type: 'cooldown';
+  duration: number;
+  powerLow: number;
+  powerHigh: number;
+};
+
+const parseWorkoutFile = (
+  workoutFileElement: XmlElement
+): { workout: ZwoWorkout | null; errors: Set<string> } => {
+  const workoutElement = findXmlElementChildWithName(
+    workoutFileElement,
+    'workout'
+  );
+  if (!workoutElement) {
+    return {
+      workout: null,
+      errors: new Set([`Invalid ZWO-file: workout-element is missing`]),
+    };
+  }
+
+  const workoutParts = new Array<ZwoWorkoutPart>();
+
+  const workoutPartErrors = new Set<string>();
+  workoutElement.children.forEach((workoutPartElement) => {
+    if (!isXmlElement(workoutPartElement)) {
+      return;
+    }
+    const parsedWorkoutPart = parseWorkoutPart(workoutPartElement);
+
+    parsedWorkoutPart.errors.forEach((error) => workoutPartErrors.add(error));
+
+    if (parsedWorkoutPart.workoutPart) {
+      workoutParts.push(parsedWorkoutPart.workoutPart);
+    }
+  });
+  const nameText = findXmlElementChildWithName(
+    workoutFileElement,
+    'name'
+  )?.children?.at(0);
+  const name = nameText instanceof XmlText ? nameText.text : 'ZWO workout';
+
+  return { workout: { parts: workoutParts, name }, errors: workoutPartErrors };
+};
+
+const findXmlElementChildWithName = (
+  xmlNode: XmlElement,
+  targetName: string
+): XmlElement | null => {
+  for (const child of xmlNode.children) {
+    if (isXmlElement(child) && child.name === targetName) {
+      return child;
+    }
+  }
+  return null;
+};
+
+const zwoWorkoutToDundringWorkout = (zwoWorkout: ZwoWorkout): Workout => {
+  const toPart = (duration: number, power: number): WorkoutPart => {
+    return {
+      duration,
+      targetPower: Math.round(power * 1000) / 10,
+      type: 'steady',
+    };
+  };
+
+  const convertPart = (part: ZwoWorkoutPart): WorkoutPart[] => {
+    switch (part.type) {
+      case 'steadystate':
+        return [toPart(part.duration, part.power)];
+      case 'freeride':
+        return [toPart(part.duration, 0)];
+      case 'cooldown':
+      case 'ramp':
+      case 'warmup':
+        return [
+          toPart(part.duration / 3, part.powerLow),
+          toPart(
+            part.duration / 3,
+            part.powerHigh - (part.powerHigh - part.powerLow) / 2
+          ),
+          toPart(part.duration / 3, part.powerHigh),
+        ];
+
+      case 'intervals':
+        return Array(part.repeat)
+          .fill('')
+          .flatMap((_) => [
+            toPart(part.onDuration, part.onPower),
+            toPart(part.offDuration, part.offPower),
+          ]);
+    }
+  };
+
+  return {
+    id: '',
+    name: zwoWorkout.name,
+    parts: zwoWorkout.parts.flatMap(convertPart),
+  };
+};
+
+const parseWorkoutPart = (
+  workoutPartElement: XmlElement
+): { workoutPart: ZwoWorkoutPart | null; errors: Set<string> } => {
+  const errors = new Set<string>();
+
+  const parseAttribute = (attribute: string, type: 'int' | 'float'): number => {
+    const value = workoutPartElement.attributes[attribute];
+    if (!value) {
+      errors.add(
+        `Attribute missing for: ${workoutPartElement.name} - ${attribute}`
+      );
+      return 0;
+    }
+    const parsedNumber =
+      type === 'int' ? parseInt(value, 10) : parseFloat(value);
+
+    if (isNaN(parsedNumber)) {
+      errors.add(`Invalid number: ${workoutPartElement.name} - ${attribute}`);
+      return 0;
+    }
+    return parsedNumber;
+  };
+
+  const parseResult = (workoutPart: ZwoWorkoutPart | null) => ({
+    workoutPart,
+    errors,
+  });
+
+  switch (workoutPartElement.name) {
+    case 'SteadyState':
+      return parseResult({
+        type: 'steadystate',
+        duration: parseAttribute('Duration', 'int'),
+        power: parseAttribute('Power', 'float'),
+      });
+    case 'IntervalsT':
+      return parseResult({
+        type: 'intervals',
+        repeat: parseAttribute('Repeat', 'int'),
+        onPower: parseAttribute('OnPower', 'float'),
+        offPower: parseAttribute('OffPower', 'float'),
+        onDuration: parseAttribute('OnDuration', 'int'),
+        offDuration: parseAttribute('OffDuration', 'int'),
+      });
+    case 'FreeRide':
+      return parseResult({
+        type: 'freeride',
+        duration: parseAttribute('Duration', 'int'),
+      });
+    case 'Ramp':
+    case 'Warmup':
+      return parseResult({
+        type: 'warmup',
+        duration: parseAttribute('Duration', 'int'),
+        powerLow: parseAttribute('PowerLow', 'float'),
+        powerHigh: parseAttribute('PowerHigh', 'float'),
+      });
+    case 'Cooldown':
+      return parseResult({
+        type: 'cooldown',
+        duration: parseAttribute('Duration', 'int'),
+        powerLow: parseAttribute('PowerLow', 'float'),
+        powerHigh: parseAttribute('PowerHigh', 'float'),
+      });
+    default: {
+      const msg = `Unsupported event ${workoutPartElement.name}`;
+      console.error(msg);
+      errors.add(msg);
+      return parseResult(null);
+    }
+  }
+};
+
+const isXmlElement = (x: any): x is XmlElement => {
+  return x instanceof XmlElement;
+};

--- a/apps/frontend/src/utils/ZwoParsing.ts
+++ b/apps/frontend/src/utils/ZwoParsing.ts
@@ -10,7 +10,7 @@ export const parseZwoWorkout = (
     if (!isXmlElement(workoutFileElement)) {
       return {
         workout: null,
-        errors: new Set([`Invalid ZWO-file: Missing children-element`]),
+        errors: new Set([`Invalid .zwo file: Missing children element`]),
       };
     }
     const zwoWorkout = parseWorkoutFile(workoutFileElement);
@@ -24,7 +24,7 @@ export const parseZwoWorkout = (
     console.error(err);
     return {
       workout: null,
-      errors: new Set([`Invalid ZWO-file: ${err}`]),
+      errors: new Set([`Invalid .zwo file: ${err}`]),
     };
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,11 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.1.tgz#221fd31a65186b9bc027b74573485fb3226dff7f"
   integrity sha512-zcU0gM3z+3iqj8UX45AmWY810l3oUmXM7uH4dt5xtzvMhRtYVhKGOmgOd1877dOPPepfCjUv57w+syamWIYe7w==
 
+"@rgrove/parse-xml@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rgrove/parse-xml/-/parse-xml-4.1.0.tgz#ff489b59c4794569fa1b798515eef6826daeeb5e"
+  integrity sha512-pBiltENdy8SfI0AeR1e5TRpS9/9Gl0eiOEt6ful2jQfzsgvZYWqsKiBWaOCLdocQuk0wS7KOHI37n0C1pnKqTw==
+
 "@rollup/plugin-typescript@^12.1.1":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-12.1.1.tgz#008d16b8283a422650c463f99ae0c610cf6c9727"


### PR DESCRIPTION
Adds the possiblity to upload .zwo-files that are parsed into dundring.com-workouts.

<img width="756" alt="image" src="https://github.com/user-attachments/assets/09ae552c-6025-4969-b88b-24e66e09089d">

Design is ofc up for discussion and fixes pushed directly to the branch are welcomed

There are a lot of events in zwo that we can't currently support, but for f.ex. trainingpeaks exports, 
this will cover the events in normal workouts.


## Errors
Regarding errors, I have taken a try-to-do-something-when-encoutering-bad-data approach, 
since this is kind of a beta feature.
Therefore this will only fail hard if it doesnt find necessary data (the workout element and such), but for
missing attributes such as power, duration or unparsable numbers, it will default to 0, 
but it will give a warning in form of a toast.


Partially solves #398 and MVP-version of #185 

## Default test .zwo-file
```
<workout_file>
	<author>Edvard Viggaklev Bakken (via TrainingPeaks)</author>
	<name>JOIN Cycling - 5x 4 min VO2max</name>
	<description>5x 4 minute VO2max intervals. Go all out, but try to perform evenly across all intervals.</description>
	<sportType>bike</sportType>
	<tags/>
	<workout>
		<SteadyState Duration="2400" Power="0.65" Cadence="90">
		</SteadyState>
		<IntervalsT Repeat="5" OnDuration="240" OnPower="1.08" OffDuration="300" OffPower="0.55" Cadence="100" CadenceResting="85" >
		</IntervalsT>
		<SteadyState Duration="2100" Power="0.65" Cadence="90">
		</SteadyState>
	</workout>
</workout_file>
```

(Funny Mac/Chrome/Spectacle-bug in action in the gifs when the file-upload moves the window 🙃 )

## Correct file =>  parsed with no warning
![2024-10-13 17 48 32](https://github.com/user-attachments/assets/ef3335fd-109e-4fea-ba80-c9f8c248fed9)


## Missing workout => no parse with Error

![2024-10-13 17 48 49](https://github.com/user-attachments/assets/6611c21e-1aff-4ea4-97df-af27514245d2)

## Missing duration => workout parsed, but with warning and missing duration to 0


![2024-10-13 17 49 07](https://github.com/user-attachments/assets/5ea7e19b-ed8f-4ff2-94d7-3f5071eb29b2)


