### PR TITLE
Fix WorkoutIntervalInput React issues

### DIFF
--- a/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
@@ -83,17 +83,6 @@ export const WorkoutIntervalInput = ({
   ftp,
   isLastWorkoutPart,
 }: Props) => {
-  const updateWorkout = (
-    data: Data,
-    setWorkoutPart: (part: WorkoutPart) => void
-  ) => {
-    setWorkoutPart({
-      duration: data.seconds,
-      targetPower: data.power,
-      type: data.type,
-    });
-    return data;
-  };
   const reducer = (currentData: Data, action: DataAction): Data => {
     switch (action.type) {
       case 'UPDATE_TIME': {
@@ -109,7 +98,7 @@ export const WorkoutIntervalInput = ({
           seconds: duration,
         };
 
-        return updateWorkout(updatedData, action.setWorkoutPart);
+        return updatedData;
       }
 
       case 'UPDATE_TIME_SECONDS':
@@ -137,7 +126,7 @@ export const WorkoutIntervalInput = ({
           power: ftpPercentFromWatt(parsed, ftp),
         };
 
-        return updateWorkout(updatedData, action.setWorkoutPart);
+        return updatedData;
       }
 
       case 'UPDATE_POWER_PERCENT': {
@@ -159,7 +148,7 @@ export const WorkoutIntervalInput = ({
           power: parsed,
         };
 
-        return updateWorkout(updatedData, action.setWorkoutPart);
+        return updatedData;
       }
       case 'FTP_UPDATED': {
         return {
@@ -196,6 +185,19 @@ export const WorkoutIntervalInput = ({
     powerWattInput: '' + wattFromProps,
     type: 'steady',
   });
+
+  React.useEffect(() => {
+    if (
+      workoutPart.duration !== data.seconds ||
+      workoutPart.targetPower !== data.power
+    ) {
+      setWorkoutPart({
+        duration: data.seconds,
+        targetPower: data.power,
+        type: data.type,
+      });
+    }
+  }, [data, setWorkoutPart]);
 
   const durationIsInvalid = false;
   const powerIsInvalid = data.power < 0;

--- a/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
+++ b/apps/frontend/src/components/WorkoutMenu/WorkoutIntervalInput.tsx
@@ -27,28 +27,23 @@ interface Data {
 interface UpdateTimeSeconds {
   type: 'UPDATE_TIME_SECONDS';
   value: string;
-  setWorkoutPart: (workoutPart: WorkoutPart) => void;
 }
 interface UpdateTimeMinutes {
   type: 'UPDATE_TIME_MINUTES';
   value: string;
-  setWorkoutPart: (workoutPart: WorkoutPart) => void;
 }
 interface UpdateTime {
   type: 'UPDATE_TIME';
-  setWorkoutPart: (workoutPart: WorkoutPart) => void;
 }
 interface UpdatePowerWatt {
   type: 'UPDATE_POWER_WATT';
   value: string;
   ftp: number;
-  setWorkoutPart: (workoutPart: WorkoutPart) => void;
 }
 interface UpdatePowerPercent {
   type: 'UPDATE_POWER_PERCENT';
   value: string;
   ftp: number;
-  setWorkoutPart: (workoutPart: WorkoutPart) => void;
 }
 
 interface FtpUpdated {
@@ -217,13 +212,11 @@ export const WorkoutIntervalInput = ({
               dispatchDataUpdate({
                 type: 'UPDATE_TIME_MINUTES',
                 value: e.target.value,
-                setWorkoutPart,
               })
             }
             onBlur={() =>
               dispatchDataUpdate({
                 type: 'UPDATE_TIME',
-                setWorkoutPart,
               })
             }
           />
@@ -240,13 +233,11 @@ export const WorkoutIntervalInput = ({
               dispatchDataUpdate({
                 type: 'UPDATE_TIME_SECONDS',
                 value: e.target.value,
-                setWorkoutPart,
               });
             }}
             onBlur={() =>
               dispatchDataUpdate({
                 type: 'UPDATE_TIME',
-                setWorkoutPart,
               })
             }
           />
@@ -269,7 +260,6 @@ export const WorkoutIntervalInput = ({
                 type: 'UPDATE_POWER_WATT',
                 value: e.target.value,
                 ftp,
-                setWorkoutPart,
               });
             }}
           />
@@ -287,7 +277,6 @@ export const WorkoutIntervalInput = ({
                 type: 'UPDATE_POWER_PERCENT',
                 value: e.target.value,
                 ftp,
-                setWorkoutPart,
               });
             }}
           />


### PR DESCRIPTION
`WorkoutIntervalInput` had some issues due to calling the parent when rendering.
This was because the usage of the setWorkoutPart from the parent was not contained in useEffect.
This lead to warnings such as this:

```console
WorkoutEditor.tsx:243 Warning: Cannot update a component (`WorkoutEditor`) while rendering a different component (`WorkoutIntervalInput`). To locate the bad setState() call inside `WorkoutIntervalInput`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render Error Component Stack
    at WorkoutIntervalInput (WorkoutIntervalInput.tsx:79:3)
    at div (<anonymous>)
    at chunk-XTFHVF2A.js?v=14ae4dba:1397:45
    at ChakraComponent (chunk-XTFHVF2A.js?v=14ae4dba:8474:35)
    at Draggable (react-beautiful-dnd.…?v=537c04d4:7953:39)
    at ConnectFunction (react-beautiful-dnd.js?v=537c04d4:848:48)
    at PrivateDraggable (react-beautiful-dnd.…?v=537c04d4:8242:26)
    at PublicDraggable (react-beautiful-dnd.…?v=537c04d4:8250:32)
    at DraggableItem (DraggableItem.tsx:10:33)
    at div (<anonymous>)
    at chunk-XTFHVF2A.js?v=14ae4dba:1397:45
    at ChakraComponent (chunk-XTFHVF2A.js?v=14ae4dba:8474:35)
    at chunk-OGF3B5P3.js?v=14ae4dba:342:5
    at Droppable (react-beautiful-dnd.…?v=537c04d4:8261:49)
    at ConnectFunction (react-beautiful-dnd.js?v=537c04d4:848:48)
    at Provider (react-beautiful-dnd.js?v=537c04d4:678:20)
    at App (react-beautiful-dnd.…?v=537c04d4:7082:25)
    at ErrorBoundary2 (react-beautiful-dnd.…?v=537c04d4:1579:35)
    at DragDropContext (react-beautiful-dnd.…?v=537c04d4:7202:19)
    at DraggableList (DraggableList.tsx:8:33)
    at div (<anonymous>)
    at chunk-XTFHVF2A.js?v=14ae4dba:1397:45
    at ChakraComponent (chunk-XTFHVF2A.js?v=14ae4dba:8474:35)
    at chunk-OGF3B5P3.js?v=14ae4dba:342:5
    at WorkoutEditor (WorkoutEditor.tsx:62:12)
```

Fixed by having the call in useEffect.
(That lead to a lot of rerenders, so add an if-check to just setTheWorkoutPart when it is actually changed)

Also removed the setWorkoutType from the actions, and just used the one from props

Not a React Expert, so it may be fixed in a better way. useMemo in the parent? IDK

## Master (bug)
![2024-10-17 21 22 50](https://github.com/user-attachments/assets/4669c584-34c7-4251-ba92-8bdeb3bd2d9f)


## This pr (no warning :) ) 
![2024-10-17 21 21 34](https://github.com/user-attachments/assets/6a5d9311-eead-420f-be63-1d2951d43425)
