### PR TITLE
Right Y-axis for HR

### DIFF
--- a/apps/frontend/src/components/DataChart.tsx
+++ b/apps/frontend/src/components/DataChart.tsx
@@ -93,7 +93,7 @@ interface Props {
   showFill: boolean;
 }
 
-export const PowerChart = ({
+export const DataChart = ({
   allMerged,
   otherUsers,
   showOtherUsersData,

--- a/apps/frontend/src/components/Graphs.tsx
+++ b/apps/frontend/src/components/Graphs.tsx
@@ -5,7 +5,7 @@ import { useData } from '../context/DataContext';
 import { LocalRoom } from '../context/WebsocketContext';
 import { ShowData } from './Graph/GraphContainer';
 import { PowerBar } from './PowerBar';
-import { DataPoint, PowerChart } from './PowerChart';
+import { DataPoint, DataChart } from './DataChart';
 import { Map } from './Map/Map';
 
 interface Props {
@@ -122,7 +122,7 @@ export const Graphs = ({
           </AspectRatio>
         )}
         <AspectRatio ratio={16 / 9} width="100%">
-          <PowerChart
+          <DataChart
             allMerged={allMerged}
             otherUsers={otherUsers}
             showOtherUsersData={showOtherUsersData}

--- a/apps/frontend/src/components/PowerBar.tsx
+++ b/apps/frontend/src/components/PowerBar.tsx
@@ -1,4 +1,11 @@
-import { ResponsiveContainer, BarChart, YAxis, Tooltip, Bar } from 'recharts';
+import {
+  ResponsiveContainer,
+  BarChart,
+  YAxis,
+  Tooltip,
+  Bar,
+  XAxis,
+} from 'recharts';
 import { CustomChartTooltip } from './Graph/CustomChartTooltip';
 import { powerColors } from '../colors';
 import React from 'react';
@@ -64,6 +71,7 @@ export const PowerBar = ({
         {fillBarChart('You', true, 0)}
         {otherUsers.map((username, i) => fillBarChart(username, true, i + 1))}
         <YAxis />
+        <XAxis tick={false} />
         <Tooltip content={<CustomChartTooltip />} cursor={false} />
       </BarChart>
     </ResponsiveContainer>

--- a/apps/frontend/src/components/PowerChart.tsx
+++ b/apps/frontend/src/components/PowerChart.tsx
@@ -1,8 +1,16 @@
-import { AreaChart, YAxis, Tooltip, Area, ResponsiveContainer } from 'recharts';
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import { CustomGraphTooltip } from './Graph/CustomGraphTooltip';
 import { hrColors, powerColors, untrackedColor } from '../colors';
 import { ShowData } from './Graph/GraphContainer';
 import React from 'react';
+import { secondsToHoursMinutesAndSecondsString } from '@dundring/utils';
 
 const fillAreaChart = (
   dataPrefix: string,
@@ -22,6 +30,7 @@ const fillAreaChart = (
   const powerGradientId = dataPrefix + 'colorPower';
   const showHr = type === 'hr' && checked.hr;
   const showPower = type === 'power' && checked.power;
+
   return (
     <React.Fragment key={index}>
       {showFill ? (
@@ -54,6 +63,7 @@ const fillAreaChart = (
           fill={`url(#${hrGradientId})`}
           animationDuration={0}
           width={20}
+          yAxisId={'hrYAxis'}
         />
       ) : null}
       {showPower ? (
@@ -63,6 +73,7 @@ const fillAreaChart = (
           fill={`url(#${powerGradientId})`}
           animationDuration={0}
           width={20}
+          yAxisId={'powerYAxis'}
         />
       ) : null}
     </React.Fragment>
@@ -128,7 +139,27 @@ export const PowerChart = ({
         {fillAreaChart('You', showUserData, 0, showFill, 'hr')}
         {fillAreaChart('You-Untracked', showUserData, 0, showFill, 'hr', true)}
 
-        <YAxis />
+        <YAxis
+          yAxisId="powerYAxis"
+          orientation="left"
+          label={{ value: 'Power', angle: -90, position: 'insideLeft' }}
+          stroke={powerColors[0]}
+        />
+
+        <YAxis
+          yAxisId="hrYAxis"
+          orientation="right"
+          domain={['dataMin - 20', 'dataMax+20']}
+          stroke={hrColors[0]}
+          label={{ value: 'HR', angle: -90, position: 'insideRight' }}
+        />
+        <XAxis
+          interval={0}
+          tickFormatter={(value: any) => {
+            return '-' + secondsToHoursMinutesAndSecondsString(500 - value);
+          }}
+          ticks={[140, 260, 380]} /* ticks to get -2 min, -4min, -6min */
+        />
         <Tooltip content={<CustomGraphTooltip />} />
       </AreaChart>
     </ResponsiveContainer>


### PR DESCRIPTION
* Adds right y axis to be able to see hr-changes better, with a smaller domain. +-20 seems To be decent in not being too large and also not too small, so that very small jumps actually seems small
* Adds coloring and labels to the y-axises
* Adds -2:00, -4:00 and -6:00 ticks to x axis
* Adds x-axis (or just a line) below the PowerBar. Added to have the charts aligned, but actually looks more neat (to me)
* Chore🤠: Renames PowerChart to DataChart


## HR
![2024-10-20 14 24 39](https://github.com/user-attachments/assets/62473e79-39bd-4815-92b1-69904896776a)

## Power
![2024-10-20 14 24 14](https://github.com/user-attachments/assets/4e72f93c-9dc4-451c-a8b7-3e65473db093)

# Starting page changes

## Current
<img width="1583" alt="image" src="https://github.com/user-attachments/assets/3056c5e1-b2fc-499a-acc3-20b00fbde74d">


# PR: Starting page
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/2b842a7a-c666-47b3-9ab1-ac6f5381e0a5">

I guess the x-axis ticks could be confusing. But so is also the 1-2-3-4 y axis in the power bar.
I don't think the changes to the starting page here are a blocker, but
if it is. I think maybe the solution is to maybe hide both charts when the are noe data to display.
Should pretty easy. WDUT, @sivertschou ?
