### PR TITLE
Remove unused prisma dependency in @dundring/backend

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,7 +36,6 @@
     "@types/nodemailer": "^6.4.6",
     "@types/ws": "^8.2.1",
     "nodemon": "^3.1.0",
-    "prisma": "^5.22.0",
     "ts-node": "^10.9.1",
     "typescript": "5.3.3"
   }


### PR DESCRIPTION
We have the dependency in `@dundring/database`, so this is not needed anymore