### PR TITLE
Fix wakelock bug - reacquire lock when refocusing tab

### DIFF
--- a/apps/frontend/src/context/DataContext.tsx
+++ b/apps/frontend/src/context/DataContext.tsx
@@ -202,7 +202,6 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
     }
   );
 
-  const [wakeLock, setWakeLock] = React.useState<WakeLockSentinel | null>(null);
   const { logEvent } = useLogs();
   const {
     isConnected: smartTrainerIsConnected,
@@ -265,12 +264,6 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
       syncResistance();
     }
 
-    try {
-      const wl = await navigator.wakeLock.request('screen');
-      setWakeLock(wl);
-    } catch (e) {
-      console.warn('Could not acquire wakeLock');
-    }
     startActiveWorkout();
     clockWorker.postMessage('startClockTimer');
     dispatch({ type: 'START' });
@@ -289,13 +282,8 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
       setResistance(0);
     }
 
-    if (wakeLock) {
-      await wakeLock.release();
-      setWakeLock(null);
-    }
-
     clockWorker.postMessage('stopClockTimer');
-  }, [clockWorker, logEvent, smartTrainerIsConnected, setResistance, wakeLock]);
+  }, [clockWorker, logEvent, smartTrainerIsConnected, setResistance]);
 
   return (
     <DataContext.Provider

--- a/apps/frontend/src/context/WakeLockContext.tsx
+++ b/apps/frontend/src/context/WakeLockContext.tsx
@@ -11,6 +11,16 @@ export const WakeLockContextProvider = ({
   const { isRunning } = useData();
   const [wakeLock, setWakeLock] = React.useState<WakeLockSentinel | null>(null);
 
+  const documentVisibility = React.useSyncExternalStore(
+    (callback) => {
+      document.addEventListener('visibilitychange', callback);
+      return () => {
+        document.removeEventListener('visibilitychange', callback);
+      };
+    },
+    () => document.visibilityState
+  );
+
   const acquireWakeLock = async () => {
     const wl = await navigator.wakeLock.request('screen');
     setWakeLock(wl);
@@ -19,14 +29,14 @@ export const WakeLockContextProvider = ({
     });
   };
   React.useEffect(() => {
-    if (isRunning) {
+    if (isRunning && documentVisibility === 'visible') {
       acquireWakeLock().catch(() => console.warn('Could not acquire wakeLock'));
     } else if (wakeLock) {
       wakeLock
         .release()
         .catch(() => console.warn('Could not release wakeLock'));
     }
-  }, [isRunning]);
+  }, [isRunning, documentVisibility]);
 
   return (
     <WakeLockContext.Provider value={null}>{children}</WakeLockContext.Provider>

--- a/apps/frontend/src/context/WakeLockContext.tsx
+++ b/apps/frontend/src/context/WakeLockContext.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useData } from './DataContext';
+
+const WakeLockContext = React.createContext(null);
+
+export const WakeLockContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { isRunning } = useData();
+  const [wakeLock, setWakeLock] = React.useState<WakeLockSentinel | null>(null);
+
+  const acquireWakeLock = async () => {
+    const wl = await navigator.wakeLock.request('screen');
+    setWakeLock(wl);
+    wl.addEventListener('release', () => {
+      setWakeLock(null);
+    });
+  };
+  React.useEffect(() => {
+    if (isRunning) {
+      acquireWakeLock().catch(() => console.warn('Could not acquire wakeLock'));
+    } else if (wakeLock) {
+      wakeLock
+        .release()
+        .catch(() => console.warn('Could not release wakeLock'));
+    }
+  }, [isRunning]);
+
+  return (
+    <WakeLockContext.Provider value={null}>{children}</WakeLockContext.Provider>
+  );
+};

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -15,6 +15,7 @@ import { ModalContextProvider } from './context/ModalContext';
 import { DataContextProvider } from './context/DataContext';
 import { ActiveWorkoutContextProvider } from './context/ActiveWorkoutContext';
 import { MockProvider } from './context/MockContext';
+import { WakeLockContextProvider } from './context/WakeLockContext';
 
 const cw: Worker = new WorkerBuilder(clockWorker);
 cw.postMessage('startDataTimer');
@@ -33,10 +34,12 @@ root.render(
                   <ActiveWorkoutContextProvider>
                     <WebsocketContextProvider>
                       <DataContextProvider clockWorker={cw}>
-                        <ModalContextProvider>
-                          <ColorModeScript />
-                          <App />
-                        </ModalContextProvider>
+                        <WakeLockContextProvider>
+                          <ModalContextProvider>
+                            <ColorModeScript />
+                            <App />
+                          </ModalContextProvider>
+                        </WakeLockContextProvider>
                       </DataContextProvider>
                     </WebsocketContextProvider>
                   </ActiveWorkoutContextProvider>


### PR DESCRIPTION
Current issue with wakelock is related to the wakelock releasing when changing tabs.
Then the wakelock is released.
And we never reacquire it.
This adds an event listener to document.visibilitystate and reacquires the lock when needed

This pr also moves the wakelock-code into a seperate WakeLockContext to avoid cluttering the datacontext code.
Not sure if this use of Context is "normal", but seems ok.
Ofc open to other suggestions, but i feel like this stuff should not be in DataContext at least.

## Testing
Tested a lot with console.log on PC, seems to work.

Works on android phone.

Testing on this PC is a bit chaotic due to a minimum 5 minute screensaver, but i will try

## Gifs
Added some gifs with a hacky overriding of the HR to display if wakelocked or not 🤠 

![2024-11-30 12 50 46](https://github.com/user-attachments/assets/35cc1e12-0605-4eb2-83f9-cbb0274e7cab)

![2024-11-30 12 50 30](https://github.com/user-attachments/assets/37d8e2a4-6644-493f-887e-3b55eec63e7f)
