### PR TITLE
Make tcx-files Garmin compatible

### DIFF
--- a/apps/frontend/src/context/DataContext.tsx
+++ b/apps/frontend/src/context/DataContext.tsx
@@ -82,6 +82,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
                 {
                   dataPoints: [],
                   distance: 0,
+                  duration: 0,
                   sumWatt: 0,
                   normalizedDuration: 0,
                 },
@@ -113,6 +114,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
               {
                 dataPoints: [],
                 distance: 0,
+                duration: 0,
                 sumWatt: 0,
                 normalizedDuration: 0,
               },
@@ -181,6 +183,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
               {
                 dataPoints: [...currentLap.dataPoints, dataPointWithPosition],
                 distance: currentLap.distance + deltaDistance,
+                duration: currentLap.duration + delta,
                 sumWatt: currentLap.sumWatt + pointAvgWatt,
                 normalizedDuration: dataPoint.power
                   ? currentLap.normalizedDuration + delta

--- a/apps/frontend/src/createTcxFile.ts
+++ b/apps/frontend/src/createTcxFile.ts
@@ -61,15 +61,17 @@ export const toTcxString = (laps: Lap[], distance: number): string => {
 };
 
 const lapToTCX = (lap: Lap) => {
-  const filtererdDataPoints = lap.dataPoints.filter(
+  const filteredDataPoints = lap.dataPoints.filter(
     (data) => data.heartRate || data.power
   );
 
-  if (filtererdDataPoints.length === 0) return '';
+  if (filteredDataPoints.length === 0) return '';
   return [
-    `      <Lap StartTime="${filtererdDataPoints[0].timeStamp.toISOString()}">`,
+    `      <Lap StartTime="${filteredDataPoints[0].timeStamp.toISOString()}">`,
+    `        <DistanceMeters>${lap.distance}</DistanceMeters>`,
+    `        <TotalTimeSeconds>${Math.round(lap.duration / 1000)}</TotalTimeSeconds>`,
     `        <Track>`,
-    `${filtererdDataPoints.reduce(
+    `${filteredDataPoints.reduce(
       (output, data) =>
         (output ? output + '\n' : output) +
         [

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -3,8 +3,9 @@ import { Scopes } from '@dundring/types';
 export interface Lap {
   dataPoints: DataPoint[];
   distance: number;
+  duration: number;
   sumWatt: number;
-  normalizedDuration: number;
+  normalizedDuration: number; // duration where watt > 0
 }
 export interface DataPoint {
   heartRate?: number;


### PR DESCRIPTION
Garmin Connect uses the `DistanceMeters` and
`TotalTimeSeconds` in each Lap to determine the
total distance and duration.
We currently do not have this, so garmin connect shows dundring-uploads as 0 distance and 00:00 time 🙃 

This PR adds these two fields and fixes the garmin issue.
Still works with strava ofc.

Lucky that we already had distance for each lap in the dundring info (but not used).

## Screenshots

Screenshots show that Strava and Garmin now shows the same data.
Lap-info still works.
(dundring has 0.1 distance because of flooring. We can think about showing 2 decimals i think. Can be more "fun")

### Garmin
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/1fbd4064-bd49-4c22-9395-c463b141c68f">

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/7945a055-81f7-4c5b-b054-6526297b9eba">


### Dundring
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/68c95ea5-ef1d-460a-ba9d-db11eb677605">


### Strava

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/71dd88bb-572c-4d2b-82b8-af8012a5b211">
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/75119746-184a-40b2-ac40-de5a95eeceee">
