### PR TITLE
Make libssl reachable by Prisma

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:20-alpine AS base
+# HACK: Pinned to 3.20 since 3.21 moves libfiles from /lib to /usr/lib.
+# Unpin when Prisma is upgraded
+FROM node:20-alpine3.20 AS base
 
 FROM base AS builder
 RUN apk add --no-cache libc6-compat


### PR DESCRIPTION
node:20-alpine3.21 moved some lib files from /lib to /usr/lib. Adding a temporary version pin until we are able to upgrade Prisma.