### PR TITLE
Remove unused turbo dependency in @dundring/database

### DIFF
--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "lint-staged": "^13.0.3",
-    "turbo": "^1.4.4"
+    "lint-staged": "^13.0.3"
   },
   "devDependencies": {
     "@dundring/tsconfig": "*",


### PR DESCRIPTION
Spotted that this was included in #451 – removing it, as it was added by mistake and is not in use