### PR TITLE
Add space-eventlistener to start/stop-buttons

### DIFF
--- a/apps/frontend/src/components/MainActionBar/StartButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/StartButton.tsx
@@ -1,12 +1,34 @@
 import { Button, Icon } from '@chakra-ui/react';
 import { PauseFill, PlayFill } from 'react-bootstrap-icons';
 import { useData } from '../../context/DataContext';
+import * as React from 'react';
 
 export const StartButton = () => {
   const { hasValidData, isRunning, start, stop } = useData();
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Ignore keypress for pages that is not the start-page, like /workout and /group
+      if (window.location.pathname !== '/') {
+        return;
+      }
+      if (event.code === 'Space') {
+        event.preventDefault();
+        buttonRef.current?.click();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   if (isRunning)
     return (
       <Button
+        ref={buttonRef}
         width="100%"
         size="lg"
         onClick={stop}
@@ -18,6 +40,7 @@ export const StartButton = () => {
 
   return (
     <Button
+      ref={buttonRef}
       width="100%"
       size="lg"
       onClick={start}


### PR DESCRIPTION
Thought it would be nice to have a hotkey for the most important part of dundring, namely starting and stopping the session.
I chose space, because i think it makes sense, and is kinda what i would expect.
When doing such strenuous activities such as dundring, it is nice to easily toggle the start/pause buttons, since the pc is often not in an optimal reaching distance

I guess it would be nice to display this hotkey and future hotkeys somewhere.
Either a list/table, or maybe just on hover? or both

Since space-keypress should only start the activity on the normal/start page, I have added a check 
for the current path (not !== "/").
I guess it would have been nice to have a more type based route setup, but i think that can be done later and is out of scope of this PR.

## Works when the "normal/start" page is active
![2025-01-04 19 32 33](https://github.com/user-attachments/assets/f9d9b5ed-681b-49f2-9eb2-3659e24dd566)

## Ignored in workout editor 
Same for group session modal
![2025-01-04 19 32 51](https://github.com/user-attachments/assets/77102fba-9e53-4cc3-a585-db1fb9b90970)
