### PR TITLE
Add useHotkey and use it for Start/Stop

### DIFF
--- a/apps/frontend/src/components/MainActionBar/StartButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/StartButton.tsx
@@ -1,9 +1,14 @@
 import { Button, Icon } from '@chakra-ui/react';
 import { PauseFill, PlayFill } from 'react-bootstrap-icons';
 import { useData } from '../../context/DataContext';
+import * as React from 'react';
+import { useHotkey } from '../../hooks/useHotkey';
 
 export const StartButton = () => {
   const { hasValidData, isRunning, start, stop } = useData();
+
+  useHotkey('Space', () => (isRunning ? stop() : start()));
+
   if (isRunning)
     return (
       <Button

--- a/apps/frontend/src/hooks/useHotkey.ts
+++ b/apps/frontend/src/hooks/useHotkey.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const useHotkey = (keyCode: string, callback: () => void) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code === keyCode && document.activeElement === document.body) {
+        event.preventDefault();
+        callback();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [callback, keyCode]);
+};


### PR DESCRIPTION
Alternative to @morteako's hotkey suggestion (#457), which might be a bit more WCAG friendly, as it still allows users to navigate buttons on the home screen with <kbd>Tab</kbd> and interacting with <kbd>Space</kbd>. This solution is affected by our rerendering issues, and will add and remove the event listener every major rerender/tick, while Morten's only add the listener once 😅 

If we really care about the rerendering, we could alternatively have the `useHotkey` hook using ref + click, but I feel that it might make more sense, and seem more scalable, to just pass the actual callback we want to trigger 🤓 