### PR TITLE
Max heart rate

### DIFF
--- a/apps/frontend/src/components/TopBar.tsx
+++ b/apps/frontend/src/components/TopBar.tsx
@@ -20,7 +20,14 @@ export const TopBar = () => {
   const { cadence, currentResistance } = useSmartTrainer();
   const { heartRate } = useHeartRateMonitor();
   const { activeWorkout } = useActiveWorkout();
-  const { data: laps, timeElapsed, distance, speed, smoothedPower } = useData();
+  const {
+    data: laps,
+    timeElapsed,
+    distance,
+    speed,
+    smoothedPower,
+    maxHeartRate,
+  } = useData();
   const remainingTime = getRemainingTime(activeWorkout);
 
   const secondsElapsed = Math.floor(timeElapsed / 1000);
@@ -56,6 +63,11 @@ export const TopBar = () => {
                 </Text>
                 <Text fontSize={unitFontSize}>bpm</Text>
               </Center>
+              {maxHeartRate && (
+                <Text color={hrColor} fontSize={secondaryFontSize}>
+                  Max: {maxHeartRate} bpm
+                </Text>
+              )}
             </Stack>
             <Stack spacing="0">
               <Text fontSize={secondaryFontSize}>

--- a/apps/frontend/src/context/DataContext.tsx
+++ b/apps/frontend/src/context/DataContext.tsx
@@ -16,6 +16,7 @@ const DataContext = React.createContext<{
   timeElapsed: number;
   startingTime: Date | null;
   distance: number;
+  maxHeartRate: number | null;
   speed: number;
   start: () => void;
   stop: () => void;
@@ -36,6 +37,7 @@ interface Data {
   untrackedData: DataPoint[];
   timeElapsed: number;
   distance: number;
+  maxHeartRate: number | null;
   speed: number;
   startingTime: Date | null;
   state: 'not_started' | 'running' | 'paused';
@@ -93,6 +95,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
               speed: 0,
               startingTime: new Date(),
               state: 'running',
+              maxHeartRate: null,
             };
           }
           return { ...currentData, state: 'running' };
@@ -170,6 +173,11 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
                 }
               : undefined),
           };
+
+          const newMaxHeartRate = dataPoint.heartRate
+            ? Math.max(dataPoint.heartRate, currentData.maxHeartRate || 0)
+            : currentData.maxHeartRate;
+
           return {
             ...currentData,
             untrackedData: [
@@ -178,6 +186,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
             ],
             speed: speed,
             distance: currentData.distance + deltaDistance,
+            maxHeartRate: newMaxHeartRate,
             laps: [
               ...laps.filter((_, i) => i !== laps.length - 1),
               {
@@ -201,6 +210,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
       distance: 0,
       speed: 0,
       startingTime: null,
+      maxHeartRate: null,
       state: 'not_started',
     }
   );
@@ -297,6 +307,7 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
         timeElapsed: data.timeElapsed,
         startingTime: data.startingTime,
         distance: data.distance,
+        maxHeartRate: data.maxHeartRate,
         speed: data.speed,
         start,
         stop,


### PR DESCRIPTION
Add current max heart rate to the data context and display it below the current hr.
Will not be displayed until hr data is recorded

Due to how we store and display hr, it will be lagging behind 1 second.
I don't think that is a big issue.
But if we want, we can mitigate it.
Either by doing the max of the current + maxHr in the view
or have the max-hr update be done from the HR-service

![image](https://github.com/user-attachments/assets/98d08d9b-2dee-4346-8274-115e295f9bf6)
