### PR TITLE
feat: combine power and workout controls

### DIFF
--- a/apps/frontend/src/components/MainActionBar.tsx
+++ b/apps/frontend/src/components/MainActionBar.tsx
@@ -15,8 +15,7 @@ import { useLinkColor } from '../hooks/useLinkColor';
 import { Icon } from '@chakra-ui/react';
 
 export const MainActionBar = () => {
-  const [showPowerControls, setShowPowerControls] = React.useState(false);
-  const [showWorkoutControls, setShowWorkoutControls] = React.useState(false);
+  const [showControls, setShowControls] = React.useState(false);
 
   const linkColor = useLinkColor();
 
@@ -30,8 +29,8 @@ export const MainActionBar = () => {
     <Center mb="5" mx="2">
       <Stack p="5" borderRadius="1em" bgColor={bgColor} pointerEvents="auto">
         <PausedWorkoutButtons />
-        {showWorkoutControls ? <WorkoutControls /> : null}
-        {showPowerControls ? <PowerControls /> : null}
+        {showControls ? <WorkoutControls /> : null}
+        {showControls ? <PowerControls /> : null}
 
         {!smartTrainerIsConnected ? (
           <Center>
@@ -50,11 +49,11 @@ export const MainActionBar = () => {
           <Center height="100%">
             <HStack>
               <SelectWorkoutButton />
-              <Tooltip label="Show workout controls">
+              <Tooltip label="Show controls">
                 <IconButton
-                  aria-label="Show workout controls"
-                  variant={showWorkoutControls ? 'outline' : 'solid'}
-                  onClick={() => setShowWorkoutControls((current) => !current)}
+                  aria-label="Show controls"
+                  variant={showControls ? 'outline' : 'solid'}
+                  onClick={() => setShowControls((current) => !current)}
                   icon={<Icon as={Grid3x2GapFill} />}
                 />
               </Tooltip>
@@ -65,11 +64,11 @@ export const MainActionBar = () => {
           </Center>
           <Center height="100%">
             <HStack justifyContent="flex-end">
-              <Tooltip label="Show power controls">
+              <Tooltip label="Show controls">
                 <IconButton
-                  aria-label="Show power controls"
-                  variant={showPowerControls ? 'outline' : 'solid'}
-                  onClick={() => setShowPowerControls((current) => !current)}
+                  aria-label="Show controls"
+                  variant={showControls ? 'outline' : 'solid'}
+                  onClick={() => setShowControls((current) => !current)}
                   icon={<Icon as={Grid3x2GapFill} />}
                 />
               </Tooltip>


### PR DESCRIPTION
Since they both are small, I think it is easiest to just combine them. Current solution makes it a bit hard to remember which one to click and such. Could ofc be solved another way (different icons). But I think this is an easier solution both for us and users.

One could then delete one of the buttons, but I just kept both, since it is so symmetric :))

![2025-01-08 22 09 56](https://github.com/user-attachments/assets/dda41eaf-972f-4e87-a0fa-6b828f5681cf)
