### PR TITLE
Fix interval duration bug

### DIFF
--- a/apps/frontend/src/context/ActiveWorkoutContext.tsx
+++ b/apps/frontend/src/context/ActiveWorkoutContext.tsx
@@ -88,20 +88,21 @@ export const ActiveWorkoutContextProvider = ({
           return activeWorkout;
         }
 
-        const newElapsed = action.millis + activeWorkout.partElapsedTime;
+        const newPartElapsedMillis =
+          action.millis + activeWorkout.partElapsedTime;
 
         if (!activeWorkout.workout) {
-          return { ...activeWorkout, partElapsedTime: newElapsed };
+          return { ...activeWorkout, partElapsedTime: newPartElapsedMillis };
         }
 
-        const elapsedSeconds = Math.floor(newElapsed / 1000);
-        const prevActivePart = activeWorkout.activePart;
-        const prevWorkoutParts = activeWorkout.workout.parts;
-        const currentPartDuration = prevWorkoutParts[prevActivePart].duration;
-        if (currentPartDuration <= elapsedSeconds) {
-          // Done with current part
-          if (prevActivePart === prevWorkoutParts.length - 1) {
-            // Done with every part
+        const activePartIndex = activeWorkout.activePart;
+        const activePart = activeWorkout.workout.parts[activePartIndex];
+        const partElapsedSeconds = Math.floor(newPartElapsedMillis / 1000);
+
+        // If done with current part
+        if (activePart.duration <= partElapsedSeconds) {
+          // If Done with every part
+          if (activePartIndex === activeWorkout.workout.parts.length - 1) {
             const nextState: ActiveWorkout = {
               ...activeWorkout,
               partElapsedTime: 0,
@@ -114,14 +115,14 @@ export const ActiveWorkoutContextProvider = ({
           // Only done with current part, other parts unfinished
           const nextState: ActiveWorkout = {
             ...activeWorkout,
-            partElapsedTime: newElapsed - currentPartDuration * 1000,
+            partElapsedTime: newPartElapsedMillis - activePart.duration * 1000,
             activePart: activeWorkout.activePart + 1,
           };
           action.addLap();
           return nextState;
         }
         // Current part is not finished
-        return { ...activeWorkout, partElapsedTime: newElapsed };
+        return { ...activeWorkout, partElapsedTime: newPartElapsedMillis };
       case 'START': {
         const nextState: ActiveWorkout = { ...activeWorkout, status: 'active' };
         return nextState;


### PR DESCRIPTION
Solves #473 

The first interval lasted 1 second too long, since it would need f.ex. 2 elapsed seconds to be larger than a duration of 1 second.
This worked out fine for the rest of the parts, because the would start then be initialized with the extra time (1 second)
from : newElapsed - currentPartDuration * 1000

The fix is in the [first commit ](https://github.com/sivertschou/dundring/commit/a25de649a0875c23d75a156c1e79ea89c9d63a02)
Also changed some names and comments.
The naming using prev confused me a bit, since it is actually the current, so i removed that prefix


# Gifs
Bug: Here we see that the first part lasts 2 seconds (0:01 and 0:00), even though it should only last 1
This is fixed in pr-gif, (first and all parts are just 0:01. which seems weird, but 1-second intervals are weird)

One consequence of this pr is that we now never reach 0:00, and 0:01 is now the last second displayed for an interval.
Another consequence is that the first second of every interval (not just first as before), will be shown as the full duration.
F.ex. a 5:00 interval will go from (5:00 4:59 4:58...) instead of the old (4:59)




## Current (bug)

![2025-01-23 21 03 42](https://github.com/user-attachments/assets/0ec6b189-5185-4c56-8572-d3d3702d2e1a)

## PR (fix)

![2025-01-23 21 02 21](https://github.com/user-attachments/assets/dc1376ce-4205-4b20-a4c5-46b523de39b2)
