### PR TITLE
Add Options with hiding of timers

### DIFF
--- a/apps/frontend/src/components/ActionBar.tsx
+++ b/apps/frontend/src/components/ActionBar.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@chakra-ui/react';
 import {
   BarChartLine,
   BarChartLineFill,
+  Gear,
   Heart,
   HeartFill,
   LightningCharge,
@@ -117,6 +118,11 @@ export const ActionBar = () => {
           iconColor={smartTrainerStatus === 'error' ? 'red.500' : undefined}
         />
       )}
+      <ActionBarItem
+        text="Open options"
+        icon={<Icon as={Gear} />}
+        onClick={() => navigate('/options')}
+      />
       <ActionBarItem
         text="Open group session overview"
         icon={<Icon as={activeGroupSession ? PeopleFill : People} />}

--- a/apps/frontend/src/components/Modals/Modals.tsx
+++ b/apps/frontend/src/components/Modals/Modals.tsx
@@ -5,6 +5,7 @@ import { ProfileModal } from './ProfileModal';
 import { GroupSessionModal } from './GroupSessionModal';
 import { WelcomeMessageModal } from './WelcomeMessageModal';
 import { FeedbackModal } from './FeedbackModal';
+import { OptionsModal } from './OptionsModal';
 
 export const Modals = () => {
   return (
@@ -16,6 +17,7 @@ export const Modals = () => {
       <ProfileModal />
       <WorkoutEditorModal />
       <WelcomeMessageModal />
+      <OptionsModal />
     </>
   );
 };

--- a/apps/frontend/src/components/Modals/OptionsModal.tsx
+++ b/apps/frontend/src/components/Modals/OptionsModal.tsx
@@ -1,0 +1,70 @@
+import {
+  Modal,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { useOptionsModal } from '../../context/ModalContext';
+import { useNavigate } from 'react-router-dom';
+import { Center, Stack } from '@chakra-ui/layout';
+import * as React from 'react';
+import { useReadWriteOptions } from '../../context/OptionsContext';
+import { Checkbox } from '@chakra-ui/checkbox';
+import { Tooltip } from '@chakra-ui/tooltip';
+
+export const OptionsModal = () => {
+  const { isOpen } = useOptionsModal();
+  const navigate = useNavigate();
+
+  const options = useReadWriteOptions();
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => navigate('/')}>
+      <ModalOverlay />
+      <ModalContent p="5">
+        <ModalHeader>Options</ModalHeader>
+        <ModalCloseButton />
+        <Center>
+          <Stack>
+            <OptionsCheckbox
+              option={options.showIntervalTimer}
+              tooltip={
+                'Check to have the remaing time of an interval displayed'
+              }
+              text={'Show remaining time for interval'}
+            />
+            <OptionsCheckbox
+              option={options.showTotalDurationTimer}
+              tooltip={
+                'Check to have the total duration of a session displayed'
+              }
+              text={'Show total duration timer'}
+            />
+          </Stack>
+        </Center>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+const OptionsCheckbox = (props: {
+  option: { value: boolean; set: (b: boolean) => void };
+  tooltip: string;
+  text: string;
+}) => {
+  const { option, tooltip, text } = props;
+  return (
+    // needs shouldWrapChildren to behave correctly on checkboxes
+    <Tooltip label={tooltip} shouldWrapChildren>
+      <Checkbox
+        onChange={(e) => {
+          option.set(e.target.checked);
+        }}
+        isChecked={option.value}
+      >
+        {text}
+      </Checkbox>
+    </Tooltip>
+  );
+};

--- a/apps/frontend/src/components/TopBar.tsx
+++ b/apps/frontend/src/components/TopBar.tsx
@@ -11,6 +11,8 @@ import {
 } from '../context/ActiveWorkoutContext';
 import { secondsToHoursMinutesAndSecondsString } from '@dundring/utils';
 import { Lap } from '../types';
+import React from 'react';
+import { useReadOnlyOptions } from '../context/OptionsContext';
 
 const mainFontSize = ['xl', '3xl', '7xl'];
 const unitFontSize = ['l', '2xl', '4xl'];
@@ -28,6 +30,9 @@ export const TopBar = () => {
     smoothedPower,
     maxHeartRate,
   } = useData();
+
+  const options = useReadOnlyOptions();
+
   const remainingTime = getRemainingTime(activeWorkout);
 
   const secondsElapsed = Math.floor(timeElapsed / 1000);
@@ -40,6 +45,8 @@ export const TopBar = () => {
   const isFreeMode = !currentResistance;
 
   const currentLap = laps.at(-1) || null;
+
+  const hasRemainingTime = remainingTime !== null;
 
   return (
     <Center
@@ -76,20 +83,24 @@ export const TopBar = () => {
               <Text fontSize={secondaryFontSize}>
                 {flooredDistance.toFixed(1)} km
               </Text>
-              {remainingTime !== null ? (
-                <>
-                  <Text fontSize={secondaryFontSize}>
-                    {secondsToHoursMinutesAndSecondsString(secondsElapsed)}
-                  </Text>
-                  <Text fontSize={mainFontSize}>
-                    {secondsToHoursMinutesAndSecondsString(remainingTime)}
-                  </Text>
-                </>
-              ) : (
-                <Text fontSize={mainFontSize}>
-                  {secondsToHoursMinutesAndSecondsString(secondsElapsed)}
+              ? (
+              <Text
+                visibility={
+                  options.showTotalDurationTimer ? 'visible' : 'hidden'
+                }
+                fontSize={hasRemainingTime ? secondaryFontSize : mainFontSize}
+              >
+                {secondsToHoursMinutesAndSecondsString(secondsElapsed)}
+              </Text>
+              {hasRemainingTime ? (
+                <Text
+                  visibility={options.showIntervalTimer ? 'visible' : 'hidden'}
+                  fontSize={mainFontSize}
+                >
+                  {secondsToHoursMinutesAndSecondsString(remainingTime)}
                 </Text>
-              )}
+              ) : null}
+              )
             </Stack>
             <Stack spacing="0" color={powerColor}>
               <Text fontSize={secondaryFontSize}>

--- a/apps/frontend/src/context/ModalContext.tsx
+++ b/apps/frontend/src/context/ModalContext.tsx
@@ -15,6 +15,7 @@ const ModalContext = React.createContext<{
   profileModal: Modal;
   welcomeMessageModal: Modal;
   workoutEditorModal: Modal;
+  optionsModal: Modal;
 } | null>(null);
 
 export const ModalContextProvider = ({
@@ -29,6 +30,7 @@ export const ModalContextProvider = ({
   const welcomeMessageModal: Modal = useDisclosure();
   const workoutEditorModal: Modal = useDisclosure();
   const feedbackModal: Modal = useDisclosure();
+  const optionsModal: Modal = useDisclosure();
 
   return (
     <ModalContext.Provider
@@ -40,6 +42,7 @@ export const ModalContextProvider = ({
         profileModal,
         welcomeMessageModal,
         workoutEditorModal,
+        optionsModal,
       }}
     >
       {children}
@@ -122,4 +125,14 @@ export const useWorkoutEditorModal = () => {
     );
   }
   return context.workoutEditorModal;
+};
+
+export const useOptionsModal = () => {
+  const context = React.useContext(ModalContext);
+  if (context === null) {
+    throw new Error(
+      'useOptionsModal must be used within a ModalContextProvider'
+    );
+  }
+  return context.optionsModal;
 };

--- a/apps/frontend/src/context/OptionsContext.tsx
+++ b/apps/frontend/src/context/OptionsContext.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import useLocalStorage from '../hooks/useLocalStorage';
+
+type ReadWriteOptions = Options<{ value: boolean; set: (b: boolean) => void }>;
+
+type ReadOnlyOptions = Options<boolean>;
+
+type Options<T> = {
+  showIntervalTimer: T;
+  showTotalDurationTimer: T;
+};
+
+const OptionsContext = React.createContext<ReadWriteOptions | null>(null);
+
+const useOptionSetting = (key: string, initialValue: boolean) => {
+  const [value, setValue] = useLocalStorage<boolean>(key, initialValue);
+
+  return { value, set: setValue };
+};
+
+export const OptionsContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const showIntervalTimer = useOptionSetting('showIntervalTimer', true);
+
+  const showTotalDurationTimer = useOptionSetting(
+    'showTotalDurationTimer',
+    true
+  );
+
+  return (
+    <OptionsContext.Provider
+      value={{
+        showIntervalTimer,
+        showTotalDurationTimer,
+      }}
+    >
+      {children}
+    </OptionsContext.Provider>
+  );
+};
+
+export const useReadWriteOptions: () => ReadWriteOptions = () => {
+  const context = React.useContext(OptionsContext);
+  if (context === null) {
+    throw new Error(
+      'useReadWriteOptions must be used within a OptionsContextProvider'
+    );
+  }
+  return context;
+};
+
+export const useReadOnlyOptions: () => ReadOnlyOptions = () => {
+  const context = React.useContext(OptionsContext);
+  if (context === null) {
+    throw new Error(
+      'useReadOnlyOptions must be used within a OptionsContextProvider'
+    );
+  }
+  const result = {} as ReadOnlyOptions;
+
+  Object.entries(context).forEach(
+    ([k, v]) => (result[k as keyof ReadOnlyOptions] = v.value)
+  );
+
+  return result;
+};

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export default function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (t: T) => void] {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T) => {
+    try {
+      setStoredValue(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -16,6 +16,7 @@ import { DataContextProvider } from './context/DataContext';
 import { ActiveWorkoutContextProvider } from './context/ActiveWorkoutContext';
 import { MockProvider } from './context/MockContext';
 import { WakeLockContextProvider } from './context/WakeLockContext';
+import { OptionsContextProvider } from './context/OptionsContext';
 
 const cw: Worker = new WorkerBuilder(clockWorker);
 cw.postMessage('startDataTimer');
@@ -28,24 +29,26 @@ root.render(
       <BrowserRouter>
         <LogContextProvider>
           <UserContextProvider>
-            <MockProvider>
-              <HeartRateContextProvider>
-                <SmartTrainerContextProvider>
-                  <ActiveWorkoutContextProvider>
-                    <WebsocketContextProvider>
-                      <DataContextProvider clockWorker={cw}>
-                        <WakeLockContextProvider>
-                          <ModalContextProvider>
-                            <ColorModeScript />
-                            <App />
-                          </ModalContextProvider>
-                        </WakeLockContextProvider>
-                      </DataContextProvider>
-                    </WebsocketContextProvider>
-                  </ActiveWorkoutContextProvider>
-                </SmartTrainerContextProvider>
-              </HeartRateContextProvider>
-            </MockProvider>
+            <OptionsContextProvider>
+              <MockProvider>
+                <HeartRateContextProvider>
+                  <SmartTrainerContextProvider>
+                    <ActiveWorkoutContextProvider>
+                      <WebsocketContextProvider>
+                        <DataContextProvider clockWorker={cw}>
+                          <WakeLockContextProvider>
+                            <ModalContextProvider>
+                              <ColorModeScript />
+                              <App />
+                            </ModalContextProvider>
+                          </WakeLockContextProvider>
+                        </DataContextProvider>
+                      </WebsocketContextProvider>
+                    </ActiveWorkoutContextProvider>
+                  </SmartTrainerContextProvider>
+                </HeartRateContextProvider>
+              </MockProvider>
+            </OptionsContextProvider>
           </UserContextProvider>
         </LogContextProvider>
       </BrowserRouter>

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -14,6 +14,7 @@ import {
   useProfileModal,
   useWelcomeMessageModal,
   useWorkoutEditorModal,
+  useOptionsModal,
 } from '../context/ModalContext';
 import { Modals } from '../components/Modals/Modals';
 import { BottomBar } from '../components/BottomBar';
@@ -39,6 +40,8 @@ export const MainPage = () => {
     onClose: onCloseWelcomeMessageModal,
   } = useWelcomeMessageModal();
   const feedbackModal = useFeedbackModal();
+
+  const optionsModal = useOptionsModal();
 
   React.useEffect(() => {
     const path = location.pathname.split('/')[1];
@@ -69,6 +72,10 @@ export const MainPage = () => {
         feedbackModal.onOpen();
         return;
 
+      case 'options':
+        optionsModal.onOpen();
+        return;
+
       default:
         onCloseGroupSessionModal();
         onCloseLogModal();
@@ -76,6 +83,8 @@ export const MainPage = () => {
         onCloseProfileModal();
         onCloseWorkoutEditorModal();
         feedbackModal.onClose();
+        onOpenWelcomeMessageModal();
+        optionsModal.onClose();
     }
   }, [
     location,
@@ -93,6 +102,8 @@ export const MainPage = () => {
     onCloseWorkoutEditorModal,
     onOpenWelcomeMessageModal,
     onCloseWelcomeMessageModal,
+    optionsModal.onOpen,
+    optionsModal.onClose,
   ]);
 
   return (


### PR DESCRIPTION
# Option modal
Plain checkboxes to toggle user options. Currently stored in localstorage, will probably be changed to dexie later.
Added icon to action bar

(Some gifs will have the play-interval-checkbox, but is was not included in this PR in the end. so ignore it :))

<img width="742" alt="image" src="https://github.com/user-attachments/assets/82d52347-e4ce-4e21-98f1-a91b68212c46" />


![2025-01-28 19 05 42](https://github.com/user-attachments/assets/cef8bec4-62dc-4a95-8bd7-cf7d48d7da73)

## Sane defaults and stored between refreshes
![2025-01-28 19 07 50](https://github.com/user-attachments/assets/bdc3bd1c-9a6e-48e2-96fe-626d41bf8d33)

## Hiding of timers
Added the possibility to hide the interval timer and also the total duration timer

Currently we display the interval timer as big and total as small if we are in a workout, and if we are in a non-workout context
the total is big.
I haven't done anything related to this pr. So if we hide the interval duration, the total will still be small.
I think this is less confusing. But open for change. Should be easy to fix.

![2025-01-28 19 07 50](https://github.com/user-attachments/assets/724ff892-0f56-49a3-917a-a9073eac6435)

