### PR TITLE
Only show welcome message on demand

### DIFF
--- a/apps/frontend/src/context/ModalContext.tsx
+++ b/apps/frontend/src/context/ModalContext.tsx
@@ -104,12 +104,10 @@ export const useWelcomeMessageModal = () => {
     );
   }
   return {
+    shouldShowWelcomeMessageHint:
+      parseInt(localStorage.getItem(KEY) || '0') < CURRENT_VERSION,
     isOpen: context.welcomeMessageModal.isOpen,
-    onOpen: () => {
-      if (parseInt(localStorage.getItem(KEY) || '0') < CURRENT_VERSION) {
-        context.welcomeMessageModal.onOpen();
-      }
-    },
+    onOpen: context.welcomeMessageModal.onOpen,
     onClose: () => {
       localStorage.setItem(KEY, JSON.stringify(CURRENT_VERSION));
       context.welcomeMessageModal.onClose();

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -76,8 +76,6 @@ export const MainPage = () => {
         onCloseProfileModal();
         onCloseWorkoutEditorModal();
         feedbackModal.onClose();
-
-        onOpenWelcomeMessageModal();
     }
   }, [
     location,


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![2025-01-30 19 00 41](https://github.com/user-attachments/assets/14a1ea26-76fe-4c4c-ac80-4833600d37b4)| ![2025-01-30 19 02 48](https://github.com/user-attachments/assets/530e6085-f3a1-4641-955f-a93e10f16c4d) |


Taking the space of the logs button on smaller devices. Considering removing logs completely in another PR tho 😅 