### PR TITLE
Remove tslib as dependency

### DIFF
--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -26,7 +26,6 @@
     "@rollup/plugin-typescript": "^12.1.1",
     "prisma": "^5.22.0",
     "rollup": "^4.12.0",
-    "tslib": "^2.6.2",
     "typescript": "5.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,7 +7066,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
Not sure why it was added, but I'm guessing some issues when resolving different versions from other dependencies 🤷 Seems to build fine without locally, but there might be issues when building with Docker, as this was added during the dockerization process (#265)