### PR TITLE
Remove dotenv-expand as direct dependency

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,7 +18,6 @@
     "babel-plugin-named-asset-import": "^0.3.8",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "dotenv": "^16.3.1",
-    "dotenv-expand": "^11.0.6",
     "eslint": "^8.52.0",
     "eslint-config-react-app": "^7.0.1",
     "framer-motion": "^10.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4184,14 +4184,7 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dotenv-expand@^11.0.6:
-  version "11.0.6"
-  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-11.0.6.tgz#f2c840fd924d7c77a94eff98f153331d876882d3"
-  integrity sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==
-  dependencies:
-    dotenv "^16.4.4"
-
-dotenv@^16.3.1, dotenv@^16.4.4, dotenv@^16.4.5:
+dotenv@^16.3.1, dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==


### PR DESCRIPTION
Tried to look after usage due to #444 – does not seem to be directly used by us