### PR TITLE
Don't set watt to 0 when starting a non-workout session

### DIFF
--- a/apps/frontend/src/context/ActiveWorkoutContext.tsx
+++ b/apps/frontend/src/context/ActiveWorkoutContext.tsx
@@ -170,6 +170,10 @@ export const ActiveWorkoutContextProvider = ({
     const status = activeWorkout.status;
     const workout = activeWorkout.workout;
 
+    if (status === 'active' && !workout) {
+      // Don't reset current resistance when starting non-workout session
+      return;
+    }
     if (status !== 'active' || !workout) {
       setResistance(0);
     } else {


### PR DESCRIPTION
Currently, if the watt you set before starting a non-planned workout session, is reset to 0 when starting the session.
This means that you always have to start a session and then set the watt.
Which means that you will lose some seconds (depending on how close you have your pc to your bike), after the start.
Without this reset it is much easier to just setup the whole dundring-session and just click play.

And it is also surprising and I myself can't really see any reason why one want this reset, but i guess it is a "bug", 
not a wanted flow.

The fix is to just don't adjust the resistance when the status is active and it is a non-workout session, by having a special case for it.

## Current
![2025-02-08 00 16 49](https://github.com/user-attachments/assets/ada42bb1-13f6-451a-a329-77702d7d1d66)


## This Pr
![2025-02-08 00 04 26](https://github.com/user-attachments/assets/7ac31848-ab81-4695-a134-277c63c3a98c)




## Related issues
There are also some other stuff related to this we could fix/discuss, like:
* Resets to 0 on breaks. These make more sense that reset on start, but not sure how useful it is. Also leads to having to set the resistance again after break, not ideal
* Resets to 0 when selecting a workout

I guess the whole reactive "set resistance when something changes" is nice in that it does a lot automatic, but I am maybe thinking we could have easier-to-understand flow in both code and UI with more a more explicit version.

I think we can just merge this PR before addressing these issues, because it
improves the current UX and also documents the behaviour in the code, so it should help future refactoring

