### PR TITLE
WIP: move hasValidData to workoutState and avoid refetching datapoints

### DIFF
--- a/apps/frontend/src/components/MainActionBar/DownloadTCXButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/DownloadTCXButton.tsx
@@ -1,15 +1,17 @@
 import { Button } from '@chakra-ui/button';
 import { Download } from 'react-bootstrap-icons';
-import { useData } from '../../context/DataContext';
 import { Icon } from '@chakra-ui/react';
 import { downloadTcx } from '../../createTcxFile';
+import * as db from '../../db';
 
 export const DownloadTCXButton = ({}: {}) => {
-  const { trackedData } = useData();
   return (
     <Button
       width="100%"
-      onClick={() => downloadTcx(trackedData)}
+      onClick={async () => {
+        const trackedData = await db.getTrackedData();
+        downloadTcx(trackedData);
+      }}
       leftIcon={<Icon as={Download} />}
     >
       Download TCX

--- a/apps/frontend/src/components/MainActionBar/UploadToStravaButton.tsx
+++ b/apps/frontend/src/components/MainActionBar/UploadToStravaButton.tsx
@@ -1,16 +1,15 @@
 import { Button } from '@chakra-ui/button';
 import { BoxArrowUpRight, Upload } from 'react-bootstrap-icons';
 import { toTcxString } from '../../createTcxFile';
-import { useData } from '../../context/DataContext';
 import { Icon, Tooltip, useToast } from '@chakra-ui/react';
 import * as api from '../../api';
 import { useUser } from '../../context/UserContext';
 import { ApiStatus } from '@dundring/types';
 import { useState } from 'react';
 import { useActiveWorkout } from '../../context/ActiveWorkoutContext';
+import * as db from '../../db';
 
 export const UploadToStravaButton = () => {
-  const { trackedData } = useData();
   const { user } = useUser();
   const { activeWorkout } = useActiveWorkout();
 
@@ -49,6 +48,7 @@ export const UploadToStravaButton = () => {
       width="100%"
       onClick={async () => {
         setState({ type: 'Loading' });
+        const trackedData = await db.getTrackedData();
         api
           .uploadActivity(
             user.token,

--- a/apps/frontend/src/components/Map/Map.tsx
+++ b/apps/frontend/src/components/Map/Map.tsx
@@ -8,11 +8,13 @@ import { useActiveRoute } from '../../hooks/useActiveRoute';
 
 export const Map = () => {
   const { activeRoute } = useActiveRoute();
-  const { trackedData: rawData } = useData();
+  // const { trackedData: rawData } = useData();
   const dotColor = useColorModeValue('black', 'white');
   const routeColor = useColorModeValue('#bdbdbd', '#424242');
 
   const multiplier = 40;
+
+  const rawData = [] as any[]; // TODO FIX
 
   const dataPoints = rawData
     .map((dataPoint) => dataPoint.position)

--- a/apps/frontend/src/hooks/useWorkoutState.ts
+++ b/apps/frontend/src/hooks/useWorkoutState.ts
@@ -12,17 +12,6 @@ export const useWorkoutState = () => {
   const state =
     useLiveQuery(() => db.workoutState.limit(1).last()) ?? defaultWorkoutState;
 
-  const trackedData =
-    useLiveQuery(
-      () =>
-        db.workoutDataPoint
-          .where('workoutNumber')
-          .equals(state.workoutNumber)
-          .filter((datapoint) => datapoint.tracking)
-          .toArray(),
-      [state.workoutNumber]
-    ) ?? [];
-
   const lapData =
     useLiveQuery(
       () =>
@@ -92,7 +81,6 @@ export const useWorkoutState = () => {
   return {
     state,
     graphData,
-    trackedData,
     lapData,
     firstDatapoint,
     lastDatapoint,


### PR DESCRIPTION
Seems to work
Haven't actually benchmarked (not sure how tbh 👀)
But my guess is that that query can be a bit intense, and seemed like it was fetched 4 times per second? (at the same time+-)
for some reason.

Here the components that need it, fetch the tracked data only when needed (upload and download, when clicked).
Will probably also reduce the amount of rerenders for these components.

## BUT!

This doesnt work for the Map :S
I am not sure, but could one maybe instead change to calculate a % of the route done, and then create x-y points based on that?
