### PR TITLE
Avoid IndexedDB write collisions by only writing when valid data is present

### DIFF
--- a/apps/frontend/src/context/DataContext.tsx
+++ b/apps/frontend/src/context/DataContext.tsx
@@ -81,8 +81,10 @@ export const DataContextProvider = ({ clockWorker, children }: Props) => {
         ...cadenceToInclude,
       };
 
-      db.addDatapoint(delta, data, isRunning);
-      sendData(dataPoint);
+      if (dataPoint.cadence || dataPoint.power || dataPoint.heartRate) {
+        db.addDatapoint(delta, data, isRunning);
+        sendData(dataPoint);
+      }
     },
     [heartRate, power, cadence, isRunning]
   );


### PR DESCRIPTION
This will obviously not work when some madlad opens three tabs and connects tab A to their HR monitor, tab B to their smart trainer and starts the workout in tab C, but this will at least allow us to use the IndexedDB with less chance of collisions.