### PR TITLE
Add note about moving the repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 ![](docs/logo.svg)
 
+> [!NOTE]
+> We're moving this repo from [sivertschou/dundring](https://github.com/sivertschou/dundring) to [dundring/trainer](https://github.com/dundring/trainer). The project will still be free and open source, but we're planning on moving this application application to a subdomain such as [trainer.dundring.com](https://dundring.com) and gather more services on [dundring.com](https://dundring.com)
+
 **[dundring.com](https://dundring.com) is an in-browser training application created to control and track your training with a smart bike trainer.**
 
 **dundring.com is available at [https://dundring.com](https://dundring.com) ⚡️**


### PR DESCRIPTION
We're moving the repo from sivertschou/dundring to dundring/trainer to make hosting and management easier for us, and we're planning on introducing more cycling and running related applications in the near future ⚡ 