### PR TITLE
Add dundring.com -> trainer.dundring.com migration banner

### DIFF
--- a/apps/frontend/src/components/MigrationBanner.tsx
+++ b/apps/frontend/src/components/MigrationBanner.tsx
@@ -1,0 +1,36 @@
+import { Box, Center, Text } from '@chakra-ui/layout';
+import { CloseButton, keyframes } from '@chakra-ui/react';
+import { useMigrationModal } from '../context/ModalContext';
+
+const gradientShift = keyframes`
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+
+export const MigrationBanner = ({ onDismiss }: { onDismiss: () => void }) => {
+  const { onOpen } = useMigrationModal();
+
+  return (
+    <Center
+      width="100%"
+      position="fixed"
+      top="0"
+      zIndex="banner"
+      background="linear-gradient(135deg, #92c4ea, #716fac, #92c4ea, #716fac)"
+      backgroundSize="300% 100%"
+      animation={`${gradientShift} 14s ease infinite`}
+      color="black"
+      py="1"
+      fontSize="sm"
+      fontWeight="semibold"
+    >
+      <Text cursor="pointer" onClick={onOpen} textAlign="center" px="10">
+        We're moving this page to trainer.dundring.com – read more here!
+      </Text>
+      <Box position="absolute" right="2">
+        <CloseButton size="sm" onClick={onDismiss} />
+      </Box>
+    </Center>
+  );
+};

--- a/apps/frontend/src/components/Modals/MigrationModal.tsx
+++ b/apps/frontend/src/components/Modals/MigrationModal.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@chakra-ui/layout';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { useMigrationModal } from '../../context/ModalContext';
+
+export const MigrationModal = () => {
+  const { isOpen, onClose } = useMigrationModal();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>This page is moving to trainer.dundring.com!</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb="6">
+          <Text pb="4">
+            dundring.com has been the home of this free and open source trainer
+            application since 2021, and now it's time to evolve a bit!
+          </Text>
+
+          <Text pb="4">
+            During the last years, we have been wanting to create more useful
+            and fun cycling related applications, but we have been reluctant to
+            add these to this trainer application. After lots of thinking, we
+            have decided that the best alternative is to move this application
+            to its own domain to make it possible to rework what dundring.com
+            should be, without ruining the trainer.
+          </Text>
+
+          <Text pb="4">
+            Our plan moving forward is to make dundring.com a place for a
+            collection of cycling related applications, and this move is an
+            important part of making that possible.
+          </Text>
+
+          <Text pb="4">
+            <b>TLDR;</b> This application will continue to be free, open source
+            and live at trainer.dundring.com and we're going to create more
+            cycling related applications over at dundring.com – stay tuned!
+          </Text>
+
+          <Text>- Sivert</Text>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/apps/frontend/src/components/Modals/Modals.tsx
+++ b/apps/frontend/src/components/Modals/Modals.tsx
@@ -5,6 +5,7 @@ import { ProfileModal } from './ProfileModal';
 import { GroupSessionModal } from './GroupSessionModal';
 import { WelcomeMessageModal } from './WelcomeMessageModal';
 import { FeedbackModal } from './FeedbackModal';
+import { MigrationModal } from './MigrationModal';
 import { OptionsModal } from './OptionsModal';
 
 export const Modals = () => {
@@ -12,6 +13,7 @@ export const Modals = () => {
     <>
       <FeedbackModal />
       <GroupSessionModal />
+      <MigrationModal />
       <LogModal />
       <LoginModal />
       <ProfileModal />

--- a/apps/frontend/src/components/TopBar.tsx
+++ b/apps/frontend/src/components/TopBar.tsx
@@ -17,7 +17,7 @@ const mainFontSize = ['xl', '3xl', '7xl'];
 const unitFontSize = ['l', '2xl', '4xl'];
 const secondaryFontSize = ['m', 'xl', '2xl'];
 
-export const TopBar = () => {
+export const TopBar = ({ topOffset = '0' }: { topOffset?: string }) => {
   const { cadence, currentResistance } = useSmartTrainer();
   const { heartRate } = useHeartRateMonitor();
   const { activeWorkout } = useActiveWorkout();
@@ -43,7 +43,7 @@ export const TopBar = () => {
     <Center
       width="100%"
       position="fixed"
-      top="0"
+      top={topOffset}
       lineHeight="1"
       pt="2"
       textShadow={textShadow}

--- a/apps/frontend/src/context/ModalContext.tsx
+++ b/apps/frontend/src/context/ModalContext.tsx
@@ -12,6 +12,7 @@ const ModalContext = React.createContext<{
   groupSessionModal: Modal;
   logModal: Modal;
   loginModal: Modal;
+  migrationModal: Modal;
   profileModal: Modal;
   welcomeMessageModal: Modal;
   workoutEditorModal: Modal;
@@ -25,6 +26,7 @@ export const ModalContextProvider = ({
 }) => {
   const logModal: Modal = useDisclosure();
   const loginModal: Modal = useDisclosure();
+  const migrationModal: Modal = useDisclosure();
   const profileModal: Modal = useDisclosure();
   const groupSessionModal: Modal = useDisclosure();
   const welcomeMessageModal: Modal = useDisclosure();
@@ -39,6 +41,7 @@ export const ModalContextProvider = ({
         groupSessionModal,
         logModal,
         loginModal,
+        migrationModal,
         profileModal,
         welcomeMessageModal,
         workoutEditorModal,
@@ -74,6 +77,16 @@ export const useLoginModal = () => {
     throw new Error('useLoginModal must be used within a ModalContextProvider');
   }
   return context.loginModal;
+};
+
+export const useMigrationModal = () => {
+  const context = React.useContext(ModalContext);
+  if (context === null) {
+    throw new Error(
+      'useMigrationModal must be used within a ModalContextProvider'
+    );
+  }
+  return context.migrationModal;
 };
 
 export const useProfileModal = () => {

--- a/apps/frontend/src/hooks/useMigrationBanner.ts
+++ b/apps/frontend/src/hooks/useMigrationBanner.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+const KEY = 'migrationBannerDismissed';
+
+export const useMigrationBannerDismissed = () => {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(KEY) === '1'
+  );
+
+  const dismiss = () => {
+    localStorage.setItem(KEY, '1');
+    setDismissed(true);
+  };
+
+  return { dismissed, dismiss };
+};

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -19,6 +19,8 @@ import {
 import { Modals } from '../components/Modals/Modals';
 import { BottomBar } from '../components/BottomBar';
 import { Footer } from '../components/Footer';
+import { MigrationBanner } from '../components/MigrationBanner';
+import { useMigrationBannerDismissed } from '../hooks/useMigrationBanner';
 
 export const MainPage = () => {
   const { connect } = useWebsocket();
@@ -42,6 +44,8 @@ export const MainPage = () => {
   const feedbackModal = useFeedbackModal();
 
   const optionsModal = useOptionsModal();
+  const { dismissed: bannerDismissed, dismiss: dismissBanner } =
+    useMigrationBannerDismissed();
 
   React.useEffect(() => {
     const path = location.pathname.split('/')[1];
@@ -118,7 +122,8 @@ export const MainPage = () => {
           <Footer />
         </Stack>
       </Center>
-      <TopBar />
+      {!bannerDismissed && <MigrationBanner onDismiss={dismissBanner} />}
+      <TopBar topOffset={bannerDismissed ? '0' : '26px'} />
       <ActionBar />
       <Modals />
       <BottomBar />


### PR DESCRIPTION
Adding banner for some context regaring the dundring.com to trainer.dundring.com migration

<img width="968" height="867" alt="image" src="https://github.com/user-attachments/assets/e700a4bd-a45b-442a-acf7-57c4219c3087" />

<img width="968" height="867" alt="image" src="https://github.com/user-attachments/assets/a3f60651-d2fc-482d-a04b-e041b17434e6" />

I'll do some cleanup for all references to dundring.com in a separate PR